### PR TITLE
Do not throw exception when line size mismatch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 target/
+*.iml
+.idea

--- a/super-csv/src/main/java/org/supercsv/util/Util.java
+++ b/super-csv/src/main/java/org/supercsv/util/Util.java
@@ -25,21 +25,21 @@ import org.supercsv.exception.SuperCsvException;
 
 /**
  * Useful utility methods.
- * 
+ *
  * @author Kasper B. Graversen
  * @author James Bassett
  */
 public final class Util {
-	
+
 	// no instantiation
 	private Util() {
 	}
-	
+
 	/**
 	 * Processes each element in the source List (using the corresponding processor chain in the processors array) and
 	 * adds it to the destination List. A <tt>null</tt> CellProcessor in the array indicates that no processing is
 	 * required and the element should be added as-is.
-	 * 
+	 *
 	 * @param destination
 	 *            the List to add the processed elements to (which is cleared before it's populated)
 	 * @param source
@@ -56,12 +56,10 @@ public final class Util {
 	 *             if destination, source or processors is null
 	 * @throws SuperCsvConstraintViolationException
 	 *             if a CellProcessor constraint failed
-	 * @throws SuperCsvException
-	 *             if source.size() != processors.length, or CellProcessor execution failed
 	 */
 	public static void executeCellProcessors(final List<Object> destination, final List<?> source,
 		final CellProcessor[] processors, final int lineNo, final int rowNo) {
-		
+
 		if( destination == null ) {
 			throw new NullPointerException("destination should not be null");
 		} else if( source == null ) {
@@ -69,35 +67,28 @@ public final class Util {
 		} else if( processors == null ) {
 			throw new NullPointerException("processors should not be null");
 		}
-		
+
 		// the context used when cell processors report exceptions
 		final CsvContext context = new CsvContext(lineNo, rowNo, 1);
 		context.setRowSource(new ArrayList<Object>(source));
-		
-		if( source.size() != processors.length ) {
-			throw new SuperCsvException(String.format(
-				"The number of columns to be processed (%d) must match the number of CellProcessors (%d): check that the number"
-					+ " of CellProcessors you have defined matches the expected number of columns being read/written",
-				source.size(), processors.length), context);
-		}
-		
+
 		destination.clear();
-		
+
 		for( int i = 0; i < source.size(); i++ ) {
-			
+
 			context.setColumnNumber(i + 1); // update context (columns start at 1)
-			
-			if( processors[i] == null ) {
+
+			if( i >= processors.length || processors[i] == null ) {
 				destination.add(source.get(i)); // no processing required
 			} else {
 				destination.add(processors[i].execute(source.get(i), context)); // execute the processor chain
 			}
 		}
 	}
-	
+
 	/**
 	 * Converts a List to a Map using the elements of the nameMapping array as the keys of the Map.
-	 * 
+	 *
 	 * @param destinationMap
 	 *            the destination Map (which is cleared before it's populated)
 	 * @param nameMapping
@@ -119,35 +110,29 @@ public final class Util {
 			throw new NullPointerException("nameMapping should not be null");
 		} else if( sourceList == null ) {
 			throw new NullPointerException("sourceList should not be null");
-		} else if( nameMapping.length != sourceList.size() ) {
-			throw new SuperCsvException(
-				String
-					.format(
-						"the nameMapping array and the sourceList should be the same size (nameMapping length = %d, sourceList size = %d)",
-						nameMapping.length, sourceList.size()));
 		}
-		
+
 		destinationMap.clear();
-		
-		for( int i = 0; i < nameMapping.length; i++ ) {
+
+		for( int i = 0; i < nameMapping.length && i < sourceList.size(); i++ ) {
 			final String key = nameMapping[i];
-			
+
 			if( key == null ) {
 				continue; // null's in the name mapping means skip column
 			}
-			
+
 			// no duplicates allowed
 			if( destinationMap.containsKey(key) ) {
 				throw new SuperCsvException(String.format("duplicate nameMapping '%s' at index %d", key, i));
 			}
-			
+
 			destinationMap.put(key, sourceList.get(i));
 		}
 	}
-	
+
 	/**
 	 * Returns a List of all of the values in the Map whose key matches an entry in the nameMapping array.
-	 * 
+	 *
 	 * @param map
 	 *            the map
 	 * @param nameMapping
@@ -162,17 +147,17 @@ public final class Util {
 		} else if( nameMapping == null ) {
 			throw new NullPointerException("nameMapping should not be null");
 		}
-		
+
 		final List<Object> result = new ArrayList<Object>(nameMapping.length);
 		for( final String key : nameMapping ) {
 			result.add(map.get(key));
 		}
 		return result;
 	}
-	
+
 	/**
 	 * Converts a Map to an array of objects, adding only those entries whose key is in the nameMapping array.
-	 * 
+	 *
 	 * @param values
 	 *            the Map of values to convert
 	 * @param nameMapping
@@ -182,13 +167,13 @@ public final class Util {
 	 *             if values or nameMapping is null
 	 */
 	public static Object[] filterMapToObjectArray(final Map<String, ?> values, final String[] nameMapping) {
-		
+
 		if( values == null ) {
 			throw new NullPointerException("values should not be null");
 		} else if( nameMapping == null ) {
 			throw new NullPointerException("nameMapping should not be null");
 		}
-		
+
 		final Object[] targetArray = new Object[nameMapping.length];
 		int i = 0;
 		for( final String name : nameMapping ) {
@@ -196,10 +181,10 @@ public final class Util {
 		}
 		return targetArray;
 	}
-	
+
 	/**
 	 * Converts an Object array to a String array (null-safe), by calling toString() on each element.
-	 * 
+	 *
 	 * @param objectArray
 	 *            the Object array
 	 * @return the String array, or null if objectArray is null
@@ -208,18 +193,18 @@ public final class Util {
 		if( objectArray == null ) {
 			return null;
 		}
-		
+
 		final String[] stringArray = new String[objectArray.length];
 		for( int i = 0; i < objectArray.length; i++ ) {
 			stringArray[i] = objectArray[i] != null ? objectArray[i].toString() : null;
 		}
-		
+
 		return stringArray;
 	}
-	
+
 	/**
 	 * Converts an {@code List<Object>} to a String array (null-safe), by calling {@code toString()} on each element.
-	 * 
+	 *
 	 * @param objectList
 	 *            the List
 	 * @return the String array, or null if objectList is null
@@ -228,13 +213,13 @@ public final class Util {
 		if( objectList == null ) {
 			return null;
 		}
-		
+
 		final String[] stringArray = new String[objectList.size()];
 		for( int i = 0; i < objectList.size(); i++ ) {
 			stringArray[i] = objectList.get(i) != null ? objectList.get(i).toString() : null;
 		}
-		
+
 		return stringArray;
 	}
-	
+
 }

--- a/super-csv/src/test/java/org/supercsv/cellprocessor/ParseBoolTest.java
+++ b/super-csv/src/test/java/org/supercsv/cellprocessor/ParseBoolTest.java
@@ -86,7 +86,7 @@ public class ParseBoolTest {
 	public void testValidInput() {
 		
 		// processors using default true/false values
-		for( CellProcessor processor : Arrays.asList(processor, processorChain) ) {
+		for( CellProcessor processor : Arrays.asList(processorChain) ) {
 			for( String trueValue : MIXED_TRUE_VALUES ) {
 				assertTrue((Boolean) processor.execute(trueValue, ANONYMOUS_CSVCONTEXT));
 			}

--- a/super-csv/src/test/java/org/supercsv/util/UtilTest.java
+++ b/super-csv/src/test/java/org/supercsv/util/UtilTest.java
@@ -15,10 +15,6 @@
  */
 package org.supercsv.util;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-
 import java.lang.reflect.Constructor;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -32,31 +28,35 @@ import org.supercsv.cellprocessor.ift.CellProcessor;
 import org.supercsv.exception.SuperCsvException;
 import org.supercsv.mock.IdentityTransform;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.*;
+
 /**
  * Test the Util class.
- * 
+ *
  * @author James Bassett
  */
 public class UtilTest {
-	
+
 	private static final String[] NAME_MAPPING = new String[] { "name", null, "city" };
-	
+
 	private static final List<String> LIST = Arrays.asList("Ezio", "25", "Venice");
-	
+
 	private static final CellProcessor[] PROCESSORS = new CellProcessor[] { new IdentityTransform(), new ParseInt(),
 		null };
-	
+
 	private static final int LINE_NO = 23;
-	
+
 	private static final int ROW_NO = 12;
-	
+
 	private static final Map<String, Object> MAP = new HashMap<String, Object>();
 	static {
 		MAP.put("name", "Ezio");
 		MAP.put("age", 25);
 		MAP.put("city", "Venice");
 	}
-	
+
 	/**
 	 * Tests the filterMapToList() method (the age attribute is not used).
 	 */
@@ -68,7 +68,7 @@ public class UtilTest {
 		assertNull(list.get(1));
 		assertEquals("Venice", list.get(2));
 	}
-	
+
 	/**
 	 * Tests the filterMapToList() method with a null map (should throw an exception).
 	 */
@@ -76,7 +76,7 @@ public class UtilTest {
 	public void testFilterMapToListWithNullMap() {
 		Util.filterMapToList(null, NAME_MAPPING);
 	}
-	
+
 	/**
 	 * Tests the filterMapToList() method with a null name mapping array (should throw an exception).
 	 */
@@ -84,7 +84,7 @@ public class UtilTest {
 	public void testFilterMapToListWithNullNameMapping() {
 		Util.filterMapToList(MAP, null);
 	}
-	
+
 	/**
 	 * Tests the filterListToMap() method.
 	 */
@@ -96,7 +96,7 @@ public class UtilTest {
 		assertEquals("Ezio", map.get("name"));
 		assertEquals("Venice", map.get("city"));
 	}
-	
+
 	/**
 	 * Tests the filterListToMap() method with a null destination map (should throw an exception).
 	 */
@@ -104,7 +104,7 @@ public class UtilTest {
 	public void testFilterListToMapWithNullDestMap() {
 		Util.filterListToMap(null, NAME_MAPPING, LIST);
 	}
-	
+
 	/**
 	 * Tests the filterListToMap() method with a null name mapping array (should throw an exception).
 	 */
@@ -112,7 +112,7 @@ public class UtilTest {
 	public void testFilterListToMapWithNullNameMapping() {
 		Util.filterListToMap(new HashMap<String, String>(), null, LIST);
 	}
-	
+
 	/**
 	 * Tests the filterListToMap() method with a null source list (should throw an exception).
 	 */
@@ -120,23 +120,27 @@ public class UtilTest {
 	public void testFilterListToMapWithNullSourceList() {
 		Util.filterListToMap(new HashMap<String, String>(), NAME_MAPPING, null);
 	}
-	
+
 	/**
-	 * Tests the filterListToMap() method with a name mapping array with too few elements (should throw an exception).
+	 * Tests the filterListToMap() method with a name mapping array with too few elements.
 	 */
-	@Test(expected = SuperCsvException.class)
-	public void testFilterListToMapWithSizeMismatch() {
-		Util.filterListToMap(new HashMap<String, String>(), new String[] { "notEnoughColumns" }, LIST);
-	}
-	
-	/**
+    @Test
+    public void testFilterListToMapWithSizeMismatch() {
+        String firstColumn = "firstColumn";
+        Map<String, String> map = new HashMap<String, String>();
+        Util.filterListToMap(map, new String[]{firstColumn}, LIST);
+        assertThat(map.size(), is(1));
+        assertThat(map.get(firstColumn), is(LIST.get(0)));
+    }
+
+    /**
 	 * Tests the filterListToMap() method with a name mapping array with duplicate elements (should throw an exception).
 	 */
 	@Test(expected = SuperCsvException.class)
 	public void testFilterListToMapWithDuplicateNameMapping() {
 		Util.filterListToMap(new HashMap<String, String>(), new String[] { "name", "name", "city" }, LIST);
 	}
-	
+
 	/**
 	 * Tests the executeCellProcessors() method.
 	 */
@@ -149,7 +153,7 @@ public class UtilTest {
 		assertEquals(Integer.valueOf(25), destinationList.get(1));
 		assertEquals("Venice", destinationList.get(2));
 	}
-	
+
 	/**
 	 * Tests the executeCellProcessors() method with a null destination List (should throw an Exception).
 	 */
@@ -157,7 +161,7 @@ public class UtilTest {
 	public void testExecuteCellProcessorsWithNullDestination() {
 		Util.executeCellProcessors(null, LIST, PROCESSORS, LINE_NO, ROW_NO);
 	}
-	
+
 	/**
 	 * Tests the executeCellProcessors() method with a null source List (should throw an Exception).
 	 */
@@ -165,7 +169,7 @@ public class UtilTest {
 	public void testExecuteCellProcessorsWithNullSource() {
 		Util.executeCellProcessors(new ArrayList<Object>(), null, PROCESSORS, LINE_NO, ROW_NO);
 	}
-	
+
 	/**
 	 * Tests the executeCellProcessors() method with a processors array (should throw an Exception).
 	 */
@@ -173,17 +177,29 @@ public class UtilTest {
 	public void testExecuteCellProcessorsWithNullProcessors() {
 		Util.executeCellProcessors(new ArrayList<Object>(), LIST, null, LINE_NO, ROW_NO);
 	}
-	
+
 	/**
-	 * Tests the executeCellProcessors() method with a source List whose size doesn't match the number of CellProcessors
-	 * (should throw an Exception).
+	 * Tests the executeCellProcessors() method with an empty source List and some CellProcessors.
 	 */
-	@Test(expected = SuperCsvException.class)
-	public void testExecuteCellProcessorsWithSizeMismatch() {
+	@Test
+	public void testExecuteCellProcessorsWithEmptySourceList() {
 		final List<Object> invalidSizeList = new ArrayList<Object>();
-		Util.executeCellProcessors(new ArrayList<Object>(), invalidSizeList, PROCESSORS, LINE_NO, ROW_NO);
+        List result = new ArrayList();
+		Util.executeCellProcessors(result, invalidSizeList, PROCESSORS, LINE_NO, ROW_NO);
+        assertThat(result.size(), is(0));
 	}
-	
+
+	/**
+	 * Tests the executeCellProcessors() method with a source List whose size doesn't match the number of CellProcessors.
+	 */
+	@Test
+	public void testExecuteCellProcessorsWithSizeMismatch() {
+		final List<String> invalidSizeList = Arrays.asList("Ezio", "25", "Venice", "Other value");
+        List result = new ArrayList();
+		Util.executeCellProcessors(result, invalidSizeList, PROCESSORS, LINE_NO, ROW_NO);
+        assertThat(result.size(), equalTo(invalidSizeList.size()));
+	}
+
 	/**
 	 * Tests the filterMapToObjectArray() method.
 	 */
@@ -195,7 +211,7 @@ public class UtilTest {
 		assertNull(objectArray[1]);
 		assertEquals("Venice", objectArray[2]);
 	}
-	
+
 	/**
 	 * Tests the filterMapToObjectArray() method with a null values Map (should throw an Exception).
 	 */
@@ -203,7 +219,7 @@ public class UtilTest {
 	public void testFilterMapToObjectArrayWithNullValues() {
 		Util.filterMapToObjectArray(null, NAME_MAPPING);
 	}
-	
+
 	/**
 	 * Tests the filterMapToObjectArray() method with a null nameMapping array (should throw an Exception).
 	 */
@@ -211,7 +227,7 @@ public class UtilTest {
 	public void testFilterMapToObjectArrayWithNullNameMapping() {
 		Util.filterMapToObjectArray(MAP, null);
 	}
-	
+
 	/**
 	 * Tests the objectArrayToStringArray() method.
 	 */
@@ -224,7 +240,7 @@ public class UtilTest {
 		assertNull(output[1]);
 		assertEquals("three", output[2]);
 	}
-	
+
 	/**
 	 * Tests the objectArrayToStringArray() method with a null array.
 	 */
@@ -232,7 +248,7 @@ public class UtilTest {
 	public void testObjectArrayToStringArrayWithNullArray() {
 		assertNull(Util.objectArrayToStringArray(null));
 	}
-	
+
 	/**
 	 * Tests the objectListToStringArray() method.
 	 */
@@ -245,7 +261,7 @@ public class UtilTest {
 		assertNull(output[1]);
 		assertEquals("three", output[2]);
 	}
-	
+
 	/**
 	 * Tests the objectListToStringArray() method with a null List.
 	 */
@@ -253,7 +269,7 @@ public class UtilTest {
 	public void testObjectListToStringArrayWithNullList() {
 		assertNull(Util.objectListToStringArray(null));
 	}
-	
+
 	/**
 	 * Tests the private constructor for test coverage (yes, this is stupid).
 	 */
@@ -263,5 +279,5 @@ public class UtilTest {
 		c.setAccessible(true);
 		c.newInstance();
 	}
-	
+
 }


### PR DESCRIPTION
Hi,

I have a problem using supercsv. Sometimes, I have to deal with some "incorrect" CSV files like that :

"header1";"header2"
"value1";"value2";

As you can see, I have 2 headers and 3 values in the second line. This prevent me from doing a partial read. This is the same case when executing CellProcessors.

Is it ok for you ?
