### PR TITLE
Option to limit the lines a record can span

### DIFF
--- a/super-csv/src/main/java/org/supercsv/prefs/CsvPreference.java
+++ b/super-csv/src/main/java/org/supercsv/prefs/CsvPreference.java
@@ -134,7 +134,9 @@ public final class CsvPreference {
 	private final QuoteMode quoteMode;
 	
 	private final CommentMatcher commentMatcher;
-	
+
+	private int maxLinesPerRow = 0;
+
 	/**
 	 * Constructs a new <tt>CsvPreference</tt> from a Builder.
 	 */
@@ -147,6 +149,7 @@ public final class CsvPreference {
 		this.commentMatcher = builder.commentMatcher;
 		this.encoder = builder.encoder;
 		this.quoteMode = builder.quoteMode;
+		this.maxLinesPerRow = builder.maxLinesPerRow;
 	}
 	
 	/**
@@ -220,6 +223,15 @@ public final class CsvPreference {
 	public CommentMatcher getCommentMatcher() {
 		return commentMatcher;
 	}
+
+	/**
+	 * Returns the number of max lines a row can span.
+	 *
+	 * @return the number of max lines a row can span
+	 */
+	public int getMaxLinesPerRow() {
+		return maxLinesPerRow;
+	}
 	
 	/**
 	 * Builds immutable <tt>CsvPreference</tt> instances. The builder pattern allows for additional preferences to be
@@ -242,6 +254,8 @@ public final class CsvPreference {
 		private QuoteMode quoteMode;
 		
 		private CommentMatcher commentMatcher;
+
+		private int maxLinesPerRow = 0;
 		
 		/**
 		 * Constructs a Builder with all of the values from an existing <tt>CsvPreference</tt> instance. Useful if you
@@ -259,6 +273,7 @@ public final class CsvPreference {
 			this.encoder = preference.encoder;
 			this.quoteMode = preference.quoteMode;
 			this.commentMatcher = preference.commentMatcher;
+			this.maxLinesPerRow = preference.maxLinesPerRow;
 		}
 		
 		/**
@@ -373,6 +388,20 @@ public final class CsvPreference {
 				throw new NullPointerException("quoteMode should not be null");
 			}
 			this.quoteMode = quoteMode;
+			return this;
+		}
+
+		/**
+		 * Integer indicating how many lines to read parsing a single row before an exception is thrown. This option
+		 * is valuable when dealing with possible human errors in mistyping quotes and large files that would otherwise
+		 * exhaust memory. Zero or a negative value will disable this option. The default is <tt>0</tt>.
+		 *
+		 * @param maxLinesPerRow
+		 *            integer indicating the max number of lines a row can span before an exception is thrown
+		 * @return the updated Builder
+		 */
+		public Builder maxLinesPerRow(final int maxLinesPerRow) {
+			this.maxLinesPerRow = maxLinesPerRow;
 			return this;
 		}
 		

--- a/super-csv/src/test/java/org/supercsv/cellprocessor/ParseBoolTest.java
+++ b/super-csv/src/test/java/org/supercsv/cellprocessor/ParseBoolTest.java
@@ -86,12 +86,12 @@ public class ParseBoolTest {
 	public void testValidInput() {
 		
 		// processors using default true/false values
-		for( CellProcessor processor : Arrays.asList(processor, processorChain) ) {
+		for( CellProcessor cp : Arrays.asList(processor, processorChain) ) {
 			for( String trueValue : MIXED_TRUE_VALUES ) {
-				assertTrue((Boolean) processor.execute(trueValue, ANONYMOUS_CSVCONTEXT));
+				assertTrue((Boolean) cp.execute(trueValue, ANONYMOUS_CSVCONTEXT));
 			}
 			for( String falseValue : MIXED_FALSE_VALUES ) {
-				assertFalse((Boolean) processor.execute(falseValue, ANONYMOUS_CSVCONTEXT));
+				assertFalse((Boolean) cp.execute(falseValue, ANONYMOUS_CSVCONTEXT));
 			}
 		}
 		

--- a/super-csv/src/test/java/org/supercsv/io/TokenizerTest.java
+++ b/super-csv/src/test/java/org/supercsv/io/TokenizerTest.java
@@ -313,7 +313,68 @@ public class TokenizerTest {
 				e.getMessage());
 		}
 	}
-	
+
+	/**
+	 * Tests the readColumns() method when a newline is reached in quote
+	 * scoped when a single line is only supposed to be read
+	 */
+	@Test
+	public void testQuotedFieldWithUnexpectedNewline() throws Exception {
+
+		// Row 2 has a missing trailing quote
+		final String input = "col1,col2\n" +
+				"\"foo\",\"bar\n" +
+				"\"baz\",\"zoo\"\n" +
+				"\"aaa\",\"bbb\"";
+		CsvPreference pref = new CsvPreference.Builder(NORMAL_PREFERENCE)
+				.maxLinesPerRow(1).build();
+
+		tokenizer = createTokenizer(input, pref);
+		try {
+			boolean first = tokenizer.readColumns(columns);
+			assertEquals(true , first);
+
+			tokenizer.readColumns(columns);
+			fail("should have thrown SuperCsvException");
+		}
+		catch(SuperCsvException e) {
+			assertEquals("unexpected end of line while reading quoted column on line 2",
+					e.getMessage());
+		}
+	}
+
+	/**
+	 * Tests the readColumns() method when a newline is reached in quote
+	 * scoped when two lines are only supposed to be read
+	 */
+	@Test
+	public void testQuotedFieldWithTwoMaxLines() throws Exception {
+
+		// Row 2 has a missing trailing quote
+		final String input = "col1,col2\n" +
+				"\"foo\",\"bar\n" +
+				"baz,zoo\n" +
+				"aaa,bbb";
+		CsvPreference pref = new CsvPreference.Builder(NORMAL_PREFERENCE)
+				.maxLinesPerRow(2).build();
+
+		tokenizer = createTokenizer(input, pref);
+		try {
+			boolean first = tokenizer.readColumns(columns);
+			assertEquals(true , first);
+
+			boolean second = tokenizer.readColumns(columns);
+			assertEquals(true , second);
+
+			tokenizer.readColumns(columns);
+			fail("should have thrown SuperCsvException");
+		}
+		catch(SuperCsvException e) {
+			assertEquals("max number of lines to read exceeded while reading quoted column beginning on line 2 and ending on line 4",
+					e.getMessage());
+		}
+	}
+
 	/**
 	 * Tests the readColumns() method with a leading space before the first quoted field. This is not technically valid
 	 * CSV, but the tokenizer is lenient enough to allow it. The leading spaces will be trimmed off when surrounding


### PR DESCRIPTION
Now when creating a reader, the preference of `maxLines(n)` can be used to limit the number of lines that a record can span (due to most likely human error of mistyping quotes)

Closes #33 
Closes #3

Related to #4 (as of right now, I think this closes it too with `maxLines(1)`, but I understand this takes the different behavior stance of throwing an exception rather than trying to be lenient (discussed in #33))

EDIT: I forgot to mention. This pull request also fixes a variable name collision in one of the test files, and the `maxLines`, by default is turned off so that client code won't break.
