### PR TITLE
Bugfix - Leaky reference to CsvContext in SuperCsvException.

### DIFF
--- a/super-csv/src/main/java/org/supercsv/exception/SuperCsvException.java
+++ b/super-csv/src/main/java/org/supercsv/exception/SuperCsvException.java
@@ -50,7 +50,9 @@ public class SuperCsvException extends RuntimeException {
 	 */
 	public SuperCsvException(final String msg, final CsvContext context) {
 		super(msg);
-		this.csvContext = context;
+		if (context != null) {
+			this.csvContext = context.clone();
+		}
 	}
 	
 	/**
@@ -65,7 +67,9 @@ public class SuperCsvException extends RuntimeException {
 	 */
 	public SuperCsvException(final String msg, final CsvContext context, final Throwable t) {
 		super(msg, t);
-		this.csvContext = context;
+		if (context != null) {
+			this.csvContext = context.clone();
+		}
 	}
 	
 	/**

--- a/super-csv/src/main/java/org/supercsv/exception/SuperCsvException.java
+++ b/super-csv/src/main/java/org/supercsv/exception/SuperCsvException.java
@@ -51,7 +51,7 @@ public class SuperCsvException extends RuntimeException {
 	public SuperCsvException(final String msg, final CsvContext context) {
 		super(msg);
 		if (context != null) {
-			this.csvContext = context.clone();
+			this.csvContext = new CsvContext(context);
 		}
 	}
 	
@@ -68,7 +68,7 @@ public class SuperCsvException extends RuntimeException {
 	public SuperCsvException(final String msg, final CsvContext context, final Throwable t) {
 		super(msg, t);
 		if (context != null) {
-			this.csvContext = context.clone();
+			this.csvContext = new CsvContext(context);
 		}
 	}
 	

--- a/super-csv/src/main/java/org/supercsv/util/CsvContext.java
+++ b/super-csv/src/main/java/org/supercsv/util/CsvContext.java
@@ -124,13 +124,13 @@ public class CsvContext implements Serializable, Cloneable {
 	@Override
 	public CsvContext clone()  {
 		try {
-			CsvContext bobafett = (CsvContext)super.clone();
+			CsvContext clone = (CsvContext)super.clone();
 			
 			if (this.rowSource != null) {
-				bobafett.rowSource = new ArrayList<Object>(this.rowSource.size());
-				bobafett.rowSource.addAll(this.rowSource);   // Can't clone java.lang.Object so stuck with a shallow copy
+				clone.rowSource = new ArrayList<Object>(this.rowSource.size());
+				clone.rowSource.addAll(this.rowSource);   // Can't clone java.lang.Object so stuck with a shallow copy
 			}
-			return bobafett;	
+			return clone;	
 		}
 		catch(CloneNotSupportedException e) {
 			throw new UnsupportedOperationException("Forgot to implement Cloneable. File a bug report");

--- a/super-csv/src/main/java/org/supercsv/util/CsvContext.java
+++ b/super-csv/src/main/java/org/supercsv/util/CsvContext.java
@@ -16,6 +16,7 @@
 package org.supercsv.util;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -27,7 +28,7 @@ import java.util.List;
  * @author Kasper B. Graversen
  * @author James Bassett
  */
-public class CsvContext implements Serializable {
+public class CsvContext implements Serializable, Cloneable {
 	
 	private static final long serialVersionUID = 1L;
 	
@@ -117,6 +118,23 @@ public class CsvContext implements Serializable {
 	 */
 	public void setRowSource(List<Object> rowSource) {
 		this.rowSource = rowSource;
+	}
+	
+	
+	@Override
+	public CsvContext clone()  {
+		try {
+			CsvContext bobafett = (CsvContext)super.clone();
+			
+			if (this.rowSource != null) {
+				bobafett.rowSource = new ArrayList<Object>(this.rowSource.size());
+				bobafett.rowSource.addAll(this.rowSource);   // Can't clone java.lang.Object so stuck with a shallow copy
+			}
+			return bobafett;	
+		}
+		catch(CloneNotSupportedException e) {
+			throw new UnsupportedOperationException("Forgot to implement Cloneabel. File a bug report");
+		}
 	}
 	
 	/**

--- a/super-csv/src/main/java/org/supercsv/util/CsvContext.java
+++ b/super-csv/src/main/java/org/supercsv/util/CsvContext.java
@@ -133,7 +133,7 @@ public class CsvContext implements Serializable, Cloneable {
 			return bobafett;	
 		}
 		catch(CloneNotSupportedException e) {
-			throw new UnsupportedOperationException("Forgot to implement Cloneabel. File a bug report");
+			throw new UnsupportedOperationException("Forgot to implement Cloneable. File a bug report");
 		}
 	}
 	

--- a/super-csv/src/main/java/org/supercsv/util/CsvContext.java
+++ b/super-csv/src/main/java/org/supercsv/util/CsvContext.java
@@ -133,7 +133,7 @@ public class CsvContext implements Serializable, Cloneable {
 			return clone;	
 		}
 		catch(CloneNotSupportedException e) {
-			throw new UnsupportedOperationException("Forgot to implement Cloneable. File a bug report");
+			throw new UnsupportedOperationException("This can never happen");
 		}
 	}
 	

--- a/super-csv/src/main/java/org/supercsv/util/CsvContext.java
+++ b/super-csv/src/main/java/org/supercsv/util/CsvContext.java
@@ -28,7 +28,7 @@ import java.util.List;
  * @author Kasper B. Graversen
  * @author James Bassett
  */
-public class CsvContext implements Serializable, Cloneable {
+public final class CsvContext implements Serializable {
 	
 	private static final long serialVersionUID = 1L;
 	
@@ -58,6 +58,22 @@ public class CsvContext implements Serializable, Cloneable {
 		this.lineNumber = lineNumber;
 		this.rowNumber = rowNumber;
 		this.columnNumber = columnNumber;
+	}
+	
+	/**
+	 * Constructs a new <tt>CsvContext</tt> that is a copy of the provided <tt>CsvContext</tt>. 
+	 * 
+	 * @param c the context to be copied
+	 */
+	public CsvContext(final CsvContext c)  {
+		this (c.lineNumber, c.rowNumber, c.columnNumber);
+		
+		if (c.rowSource != null) {
+			// Shallow clone is OK here. A deep clone implementation would be tricky
+			// because the declared type of the items in the array is "Object" which does not 
+			// have an exposed copy constructor or clone method.
+			this.rowSource = new ArrayList<Object>(c.rowSource);
+		}
 	}
 	
 	/**
@@ -118,23 +134,6 @@ public class CsvContext implements Serializable, Cloneable {
 	 */
 	public void setRowSource(List<Object> rowSource) {
 		this.rowSource = rowSource;
-	}
-	
-	
-	@Override
-	public CsvContext clone()  {
-		try {
-			CsvContext clone = (CsvContext)super.clone();
-			
-			if (this.rowSource != null) {
-				clone.rowSource = new ArrayList<Object>(this.rowSource.size());
-				clone.rowSource.addAll(this.rowSource);   // Can't clone java.lang.Object so stuck with a shallow copy
-			}
-			return clone;	
-		}
-		catch(CloneNotSupportedException e) {
-			throw new UnsupportedOperationException("This can never happen");
-		}
 	}
 	
 	/**

--- a/super-csv/src/test/java/org/supercsv/exception/SuperCsvCellProcessorExceptionTest.java
+++ b/super-csv/src/test/java/org/supercsv/exception/SuperCsvCellProcessorExceptionTest.java
@@ -99,4 +99,29 @@ public class SuperCsvCellProcessorExceptionTest {
 		}
 	}
 	
+	/**
+	 * Tests the integrity of the CsvContext in a <code>SuperCsvCellProcessorException</code>
+	 */
+	@Test
+	public void testCsvContext() {
+		// This is my reference context. It is the control object to use as the reference for assertions
+		CsvContext rc = new CsvContext(1, 2, 3);   // line, row, col
+		
+		// This is the test context object to use for the test. It must have the same
+		// values as the reference context. 
+		CsvContext tc = new CsvContext(rc.getLineNumber(), rc.getRowNumber(), rc.getColumnNumber()); 
+		
+		SuperCsvCellProcessorException e = new SuperCsvCellProcessorException
+			(String.class, 123, tc, PROCESSOR);
+
+		// Pre-condition check
+		assertEquals(rc, e.getCsvContext());
+		
+		// Test steps
+		tc.setColumnNumber(2*rc.getColumnNumber() + 50);   // Set a column # that is different than the reference
+		
+		// Check that the exception still returns the context that it was created with
+		assertEquals(rc, e.getCsvContext());
+	}
+	
 }

--- a/super-csv/src/test/java/org/supercsv/util/CsvContextTest.java
+++ b/super-csv/src/test/java/org/supercsv/util/CsvContextTest.java
@@ -130,23 +130,23 @@ public class CsvContextTest {
 	}
 	
 	@Test
-	public void testClone() {
-		// Test clone with the mandatory parameters. The rowSource is not set
-		// to make sure that clone() does not dereference a null
+	public void testCopyConstructor() {
+		// Test with the mandatory parameters. The rowSource is not set
+		// to make sure that copy constructor does not dereference a null
 		CsvContext original = new CsvContext(1,2,3);
-		CsvContext clone = original.clone();
+		CsvContext clone = new CsvContext(original);
 		assertFalse(original == clone);   // The clone is a new object
 		assertEquals(original, clone);    // that passes the equals test
 		
 		// Test with a homogeneous rowSource
 		original.setRowSource(Arrays.asList(new Object[] { "four", "five", "six" }));
-		CsvContext clone2 = original.clone();
+		CsvContext clone2 = new CsvContext(original);
 		assertFalse(original == clone2);   // The clone is a new object
 		assertEquals(original, clone2);    // that passes the equals test
 		
 		// Corner cases
 		original.setRowSource(Arrays.asList(new Object[] { null, "five", new Integer(6) }));
-		CsvContext clone3 = original.clone();
+		CsvContext clone3 = new CsvContext(original);
 		assertFalse(original == clone3);   // The clone is a new object
 		assertEquals(original, clone3);    // that passes the equals test
 	}

--- a/super-csv/src/test/java/org/supercsv/util/CsvContextTest.java
+++ b/super-csv/src/test/java/org/supercsv/util/CsvContextTest.java
@@ -129,4 +129,25 @@ public class CsvContextTest {
 		assertTrue(contextWithSource.equals(same));
 	}
 	
+	@Test
+	public void testClone() {
+		// Test clone with the mandatory parameters. The rowSource is not set
+		// to make sure that clone() does not dereference a null
+		CsvContext original = new CsvContext(1,2,3);
+		CsvContext clone = original.clone();
+		assertFalse(original == clone);   // The clone is a new object
+		assertEquals(original, clone);    // that passes the equals test
+		
+		// Test with a homogeneous rowSource
+		original.setRowSource(Arrays.asList(new Object[] { "four", "five", "six" }));
+		CsvContext clone2 = original.clone();
+		assertFalse(original == clone2);   // The clone is a new object
+		assertEquals(original, clone2);    // that passes the equals test
+		
+		// Corner cases
+		original.setRowSource(Arrays.asList(new Object[] { null, "five", new Integer(6) }));
+		CsvContext clone3 = original.clone();
+		assertFalse(original == clone3);   // The clone is a new object
+		assertEquals(original, clone3);    // that passes the equals test
+	}
 }


### PR DESCRIPTION
The integrity of the CsvContext stored in SuperCsvException was not being protected. So if the CsvContext was used in a subsequent operation, then we can no longer depend on SuperCsvException.getCsvContext().

This bug causes the  properties of the CsvContext to be incorrect if the file reader does anything other than hard fail at the first cell processor exception.

I ran into this problem because our CSV file reader will walk through all the cells in a record before reporting errors and the reported column number from all the cell processor exceptions encountered during the scan is always the last column number.
