### PR TITLE
#43 Error message fixed. Bug fixed when additional line is skipped

### DIFF
--- a/super-csv/src/main/java/org/supercsv/io/Tokenizer.java
+++ b/super-csv/src/main/java/org/supercsv/io/Tokenizer.java
@@ -140,9 +140,8 @@ public class Tokenizer extends AbstractTokenizer {
 					currentRow.append(NEWLINE); // specific line terminator lost, \n will have to suffice
 					
 					charIndex = 0;
-					line = readLine();
 
-					if (maxLinesPerRow > 0 && getLineNumber() - quoteScopeStartingLine + 1 > maxLinesPerRow) {
+					if (maxLinesPerRow > 0 && getLineNumber() - quoteScopeStartingLine + 1 >= maxLinesPerRow) {
 						/*
 						 * The quoted section that is being parsed spans too many lines, so to avoid excessive memory
 						 * usage parsing something that is probably human error anyways, throw an exception. If each
@@ -151,13 +150,13 @@ public class Tokenizer extends AbstractTokenizer {
 						 */
 						String msg = maxLinesPerRow == 1 ?
 								String.format("unexpected end of line while reading quoted column on line %d",
-											  getLineNumber() - 1) :
+											  getLineNumber()) :
 								String.format("max number of lines to read exceeded while reading quoted column" +
 											  " beginning on line %d and ending on line %d",
 											  quoteScopeStartingLine, getLineNumber());
 						throw new SuperCsvException(msg);
 					}
-					else if( line == null ) {
+					else if( (line = readLine()) == null ) {
 						throw new SuperCsvException(
 							String
 								.format(

--- a/super-csv/src/test/java/org/supercsv/io/TokenizerTest.java
+++ b/super-csv/src/test/java/org/supercsv/io/TokenizerTest.java
@@ -375,6 +375,83 @@ public class TokenizerTest {
 		}
 	}
 
+	@Test
+	public void testQuotedFieldWithUnexpectedNewlineNoNextLineRead() throws Exception {
+
+		// Row 2 has a missing trailing quote
+		final String input = "col1,col2\n" +
+				"\"foo\",\"bar\n" +
+				"\"baz\",\"zoo\"\n" +
+				"\"aaa\",\"bbb\"";
+		CsvPreference pref = new CsvPreference.Builder(NORMAL_PREFERENCE)
+				.maxLinesPerRow(1).build();
+
+		tokenizer = createTokenizer(input, pref);
+		try {
+			final boolean first = tokenizer.readColumns(columns);
+			assertEquals(true , first);
+			assertEquals("[col1, col2]" , columns.toString());
+
+			tokenizer.readColumns(columns);
+			fail("should have thrown SuperCsvException");
+		}
+		catch(SuperCsvException e) {
+			assertEquals("unexpected end of line while reading quoted column on line 2",
+					e.getMessage());
+		}
+		final boolean third = tokenizer.readColumns(columns);
+		assertEquals(true , third);
+		assertEquals("[baz, zoo]" , columns.toString());
+
+		final boolean fourth = tokenizer.readColumns(columns);
+		assertEquals(true , fourth);
+		assertEquals("[aaa, bbb]" , columns.toString());
+
+		//line 4 was the last 
+		final boolean fifth = tokenizer.readColumns(columns);
+		assertEquals(false , fifth);
+	}
+
+	/**
+	 * Tests the readColumns() method when a newline is reached in quote
+	 * scoped when two lines are only supposed to be read
+	 */
+	@Test
+	public void testQuotedFieldWithTwoMaxLinesNoMoreLinesRead() throws Exception {
+
+		// Row 2 has a missing trailing quote
+		final String input = "col1,col2\n" +
+				"\"foo,bar\n" +
+				"baz,zoo\n" +
+				"aaa,bbb";
+		CsvPreference pref = new CsvPreference.Builder(NORMAL_PREFERENCE)
+				.maxLinesPerRow(2).build();
+
+		tokenizer = createTokenizer(input, pref);
+		try {
+			boolean first = tokenizer.readColumns(columns);
+			assertEquals(true , first);
+			assertEquals("[col1, col2]" , columns.toString());
+			
+
+			boolean second = tokenizer.readColumns(columns);
+			assertEquals(true , second);
+			assertEquals("[\"foo,bar]" , columns.toString());
+
+
+			tokenizer.readColumns(columns);
+			fail("should have thrown SuperCsvException");
+		}
+		catch(SuperCsvException e) {
+			assertEquals("max number of lines to read exceeded while reading quoted column beginning on line 2 and ending on line 3",
+					e.getMessage());
+		}
+		boolean fourth = tokenizer.readColumns(columns);
+		assertEquals(true , fourth);
+		assertEquals("[aaa, bbb]" , columns.toString());
+		
+	}
+
 	/**
 	 * Tests the readColumns() method with a leading space before the first quoted field. This is not technically valid
 	 * CSV, but the tokenizer is lenient enough to allow it. The leading spaces will be trimmed off when surrounding

--- a/super-csv/src/test/java/org/supercsv/io/TokenizerTest.java
+++ b/super-csv/src/test/java/org/supercsv/io/TokenizerTest.java
@@ -370,7 +370,7 @@ public class TokenizerTest {
 			fail("should have thrown SuperCsvException");
 		}
 		catch(SuperCsvException e) {
-			assertEquals("max number of lines to read exceeded while reading quoted column beginning on line 2 and ending on line 4",
+			assertEquals("max number of lines to read exceeded while reading quoted column beginning on line 2 and ending on line 3",
 					e.getMessage());
 		}
 	}


### PR DESCRIPTION
Fix for issue #43 
It is fixing error message for maxLinesPerRow > 1 - current line is counted now.
No more additional line reads when there is a human error with skipping character. 