### PR TITLE
Fix getQuoteChar() returns int. Closes #32

### DIFF
--- a/super-csv/src/main/java/org/supercsv/prefs/CsvPreference.java
+++ b/super-csv/src/main/java/org/supercsv/prefs/CsvPreference.java
@@ -177,7 +177,7 @@ public final class CsvPreference {
 	 * 
 	 * @return the quote character
 	 */
-	public int getQuoteChar() {
+	public char getQuoteChar() {
 		return quoteChar;
 	}
 	


### PR DESCRIPTION
quoteChar is declared in CsvPreference as char, however, getQuoteChar()
returned an int. That prevented doing:

new
CsvPreference.Builder(CsvPreference.STANDARD_PREFERENCE.getQuoteChar(),
CsvPreference.STANDARD_PREFERENCE.getDelimiterChar(), "\n").build();

because the Builder expects char.

Closes issue #32