### PR TITLE
Parameterize the execute method so that when using the API casts can …

### DIFF
--- a/super-csv/src/main/java/org/supercsv/cellprocessor/ift/CellProcessor.java
+++ b/super-csv/src/main/java/org/supercsv/cellprocessor/ift/CellProcessor.java
@@ -32,5 +32,5 @@ public interface CellProcessor {
 	 * @return the result of cell processor execution
 	 * @since 1.0
 	 */
-	Object execute(final Object value, final CsvContext context);
+	<T> T execute(final Object value, final CsvContext context);
 }


### PR DESCRIPTION
…happen without a warning.