### PR TITLE
Multiple delimiter symbols

### DIFF
--- a/super-csv/src/main/java/org/supercsv/encoder/DefaultCsvEncoder.java
+++ b/super-csv/src/main/java/org/supercsv/encoder/DefaultCsvEncoder.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2007 Kasper B. Graversen
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,58 +20,61 @@ import org.supercsv.util.CsvContext;
 
 /**
  * The default CsvEncoder implementation.
- * 
+ *
  * @author James Bassett
  * @since 2.1.0
  */
 public class DefaultCsvEncoder implements CsvEncoder {
-	
+
 	/**
 	 * Constructs a new <tt>DefaultCsvEncoder</tt>.
 	 */
 	public DefaultCsvEncoder() {
+
 	}
-	
+
 	/**
 	 * {@inheritDoc}
 	 */
 	public String encode(final String input, final CsvContext context, final CsvPreference preference) {
-		
+
 		final StringBuilder currentColumn = new StringBuilder();
-		final int delimiter = preference.getDelimiterChar();
+		if (preference.getDelimiterSymbols().length() > 1)
+			throw new IllegalArgumentException("delimiter must be one character long");
+		final int delimiter = preference.getDelimiterSymbols().charAt(0);
 		final char quote = (char) preference.getQuoteChar();
 		final char quoteEscapeChar = (char) preference.getQuoteEscapeChar();
 		final String eolSymbols = preference.getEndOfLineSymbols();
 		final int lastCharIndex = input.length() - 1;
-		
+
 		boolean quotesRequiredForSpecialChar = false;
-		
+
 		boolean skipNewline = false;
-		
-		for( int i = 0; i <= lastCharIndex; i++ ) {
-			
+
+		for (int i = 0; i <= lastCharIndex; i++) {
+
 			final char c = input.charAt(i);
-			
-			if( skipNewline ) {
+
+			if (skipNewline) {
 				skipNewline = false;
-				if( c == '\n' ) {
+				if (c == '\n') {
 					continue; // newline following a carriage return is skipped
 				}
 			}
-			
-			if( c == delimiter ) {
+
+			if (c == delimiter) {
 				quotesRequiredForSpecialChar = true;
 				currentColumn.append(c);
-			} else if( c == quote ) {
+			} else if (c == quote) {
 				quotesRequiredForSpecialChar = true;
 				currentColumn.append(quoteEscapeChar);
 				currentColumn.append(quote);
-			} else if( c == '\r' ) {
+			} else if (c == '\r') {
 				quotesRequiredForSpecialChar = true;
 				currentColumn.append(eolSymbols);
 				context.setLineNumber(context.getLineNumber() + 1);
 				skipNewline = true;
-			} else if( c == '\n' ) {
+			} else if (c == '\n') {
 				quotesRequiredForSpecialChar = true;
 				currentColumn.append(eolSymbols);
 				context.setLineNumber(context.getLineNumber() + 1);
@@ -79,16 +82,15 @@ public class DefaultCsvEncoder implements CsvEncoder {
 				currentColumn.append(c);
 			}
 		}
-		
+
 		final boolean quotesRequiredForMode = preference.getQuoteMode().quotesRequired(input, context, preference);
 		final boolean quotesRequiredForSurroundingSpaces = preference.isSurroundingSpacesNeedQuotes()
-			&& input.length() > 0 && (input.charAt(0) == ' ' || input.charAt(input.length() - 1) == ' ');
-		
-		if( quotesRequiredForSpecialChar || quotesRequiredForMode || quotesRequiredForSurroundingSpaces ) {
+				&& input.length() > 0 && (input.charAt(0) == ' ' || input.charAt(input.length() - 1) == ' ');
+
+		if (quotesRequiredForSpecialChar || quotesRequiredForMode || quotesRequiredForSurroundingSpaces) {
 			currentColumn.insert(0, quote).append(quote);
 		}
-		
+
 		return currentColumn.toString();
 	}
-	
 }

--- a/super-csv/src/main/java/org/supercsv/io/AbstractCsvWriter.java
+++ b/super-csv/src/main/java/org/supercsv/io/AbstractCsvWriter.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2007 Kasper B. Graversen
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -27,30 +27,30 @@ import org.supercsv.util.Util;
 
 /**
  * Defines the standard behaviour of a CSV writer.
- * 
+ *
  * @author Kasper B. Graversen
  * @author James Bassett
  */
 public abstract class AbstractCsvWriter implements ICsvWriter {
-	
+
 	private final Writer writer;
-	
+
 	private final CsvPreference preference;
-	
+
 	private final CsvEncoder encoder;
-	
+
 	// the line number being written / just written
 	private int lineNumber = 0;
-	
+
 	// the row being written / just written
 	private int rowNumber = 0;
-	
+
 	// the column being written / just written
 	private int columnNumber = 0;
-	
+
 	/**
 	 * Constructs a new <tt>AbstractCsvWriter</tt> with the supplied writer and preferences.
-	 * 
+	 *
 	 * @param writer
 	 *            the stream to write to
 	 * @param preference
@@ -61,11 +61,11 @@ public abstract class AbstractCsvWriter implements ICsvWriter {
 	public AbstractCsvWriter(final Writer writer, final CsvPreference preference) {
 		this(writer, preference, true);
 	}
-	
+
 	/**
 	 * Constructs a new <tt>AbstractCsvWriter</tt> with the supplied writer, preferences and option
 	 * to wrap the writer.
-	 * 
+	 *
 	 * @param writer
 	 *            the stream to write to
 	 * @param preference
@@ -81,26 +81,26 @@ public abstract class AbstractCsvWriter implements ICsvWriter {
 		} else if( preference == null ) {
 			throw new NullPointerException("preference should not be null");
 		}
-		
+
 		this.writer = bufferizeWriter ? new BufferedWriter(writer) : writer;
 		this.preference = preference;
 		this.encoder = preference.getEncoder();
 	}
-	
+
 	/**
 	 * Closes the underlying writer, flushing it first.
 	 */
 	public void close() throws IOException {
 		writer.close();
 	}
-	
+
 	/**
 	 * Flushes the underlying writer.
 	 */
 	public void flush() throws IOException {
 		writer.flush();
 	}
-	
+
 	/**
 	 * In order to maintain the current row and line numbers, this method <strong>must</strong> be called at the very
 	 * beginning of every write method implemented in concrete CSV writers. This will allow the correct row/line numbers
@@ -112,29 +112,29 @@ public abstract class AbstractCsvWriter implements ICsvWriter {
 		lineNumber++;
 		rowNumber++;
 	}
-	
+
 	/**
 	 * {@inheritDoc}
 	 */
 	public int getLineNumber() {
 		return lineNumber;
 	}
-	
+
 	/**
 	 * {@inheritDoc}
 	 */
 	public int getRowNumber() {
 		return rowNumber;
 	}
-	
+
 	/**
 	 * Writes a List of columns as a line to the CsvWriter.
-	 * 
+	 *
 	 * @param columns
 	 *            the columns to write
 	 * @throws IllegalArgumentException
 	 *             if columns.size == 0
-	 * @throws IOException
+	 * @throws java.io.IOException
 	 *             If an I/O error occurs
 	 * @throws NullPointerException
 	 *             if columns is null
@@ -142,15 +142,15 @@ public abstract class AbstractCsvWriter implements ICsvWriter {
 	protected void writeRow(final List<?> columns) throws IOException {
 		writeRow(Util.objectListToStringArray(columns));
 	}
-	
+
 	/**
 	 * Writes one or more Object columns as a line to the CsvWriter.
-	 * 
+	 *
 	 * @param columns
 	 *            the columns to write
 	 * @throws IllegalArgumentException
 	 *             if columns.length == 0
-	 * @throws IOException
+	 * @throws java.io.IOException
 	 *             If an I/O error occurs
 	 * @throws NullPointerException
 	 *             if columns is null
@@ -158,37 +158,37 @@ public abstract class AbstractCsvWriter implements ICsvWriter {
 	protected void writeRow(final Object... columns) throws IOException {
 		writeRow(Util.objectArrayToStringArray(columns));
 	}
-	
+
 	/**
 	 * Writes one or more String columns as a line to the CsvWriter.
-	 * 
+	 *
 	 * @param columns
 	 *            the columns to write
 	 * @throws IllegalArgumentException
 	 *             if columns.length == 0
-	 * @throws IOException
+	 * @throws java.io.IOException
 	 *             If an I/O error occurs
 	 * @throws NullPointerException
 	 *             if columns is null
 	 */
 	protected void writeRow(final String... columns) throws IOException {
-		
+
 		if( columns == null ) {
 			throw new NullPointerException(String.format("columns to write should not be null on line %d", lineNumber));
 		} else if( columns.length == 0 ) {
 			throw new IllegalArgumentException(String.format("columns to write should not be empty on line %d",
 				lineNumber));
 		}
-		
+
 		StringBuilder builder = new StringBuilder();
 		for( int i = 0; i < columns.length; i++ ) {
-			
+
 			columnNumber = i + 1; // column no used by CsvEncoder
-			
+
 			if( i > 0 ) {
-				builder.append((char) preference.getDelimiterChar()); // delimiter
+				builder.append(preference.getDelimiterSymbols()); // delimiter
 			}
-			
+
 			final String csvElement = columns[i];
 			if( csvElement != null ) {
 				final CsvContext context = new CsvContext(lineNumber, rowNumber, columnNumber);
@@ -196,37 +196,37 @@ public abstract class AbstractCsvWriter implements ICsvWriter {
 				builder.append(escapedCsv);
 				lineNumber = context.getLineNumber(); // line number can increment when encoding multi-line columns
 			}
-			
+
 		}
-		
+
 		builder.append(preference.getEndOfLineSymbols()); // EOL
 		writer.write(builder.toString());
 	}
-	
+
 	/**
 	 * {@inheritDoc}
 	 */
 	public void writeComment(final String comment) throws IOException {
-		
+
 		lineNumber++; // we're not catering for embedded newlines (must be a single-line comment)
-		
+
 		if( comment == null ) {
 			throw new NullPointerException(String.format("comment to write should not be null on line %d", lineNumber));
 		}
-		
+
 		writer.write(comment + preference.getEndOfLineSymbols());
-		
+
 	}
-	
+
 	/**
 	 * {@inheritDoc}
 	 */
 	public void writeHeader(final String... header) throws IOException {
-		
+
 		// update the current row/line numbers
 		incrementRowAndLineNo();
-		
+
 		writeRow(header);
 	}
-	
+
 }

--- a/super-csv/src/main/java/org/supercsv/io/CsvBeanReader.java
+++ b/super-csv/src/main/java/org/supercsv/io/CsvBeanReader.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2007 Kasper B. Graversen
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,10 +22,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
-
 import org.supercsv.cellprocessor.ift.CellProcessor;
-import org.supercsv.exception.SuperCsvConstraintViolationException;
-import org.supercsv.exception.SuperCsvException;
 import org.supercsv.exception.SuperCsvReflectionException;
 import org.supercsv.prefs.CsvPreference;
 import org.supercsv.util.BeanInterfaceProxy;
@@ -36,23 +33,23 @@ import org.supercsv.util.MethodCache;
  * (using the supplied name mapping). The bean to populate can be either a class or interface. If a class is used, it
  * must be a valid Javabean, i.e. it must have a default no-argument constructor and getter/setter methods. An interface
  * may also be used if it defines getters/setters - a proxy object will be created that implements the interface.
- * 
+ *
  * @author Kasper B. Graversen
  * @author James Bassett
  * @author Fabian Seifert
  */
 public class CsvBeanReader extends AbstractCsvReader implements ICsvBeanReader {
-	
+
 	// temporary storage of processed columns to be mapped to the bean
 	private final List<Object> processedColumns = new ArrayList<Object>();
-	
+
 	// cache of methods for mapping from columns to fields
 	private final MethodCache cache = new MethodCache();
-	
+
 	/**
 	 * Constructs a new <tt>CsvBeanReader</tt> with the supplied Reader and CSV preferences. Note that the
 	 * <tt>reader</tt> will be wrapped in a <tt>BufferedReader</tt> before accessed.
-	 * 
+	 *
 	 * @param reader
 	 *            the reader
 	 * @param preferences
@@ -63,11 +60,11 @@ public class CsvBeanReader extends AbstractCsvReader implements ICsvBeanReader {
 	public CsvBeanReader(final Reader reader, final CsvPreference preferences) {
 		super(reader, preferences);
 	}
-	
+
 	/**
 	 * Constructs a new <tt>CsvBeanReader</tt> with the supplied (custom) Tokenizer and CSV preferences. The tokenizer
 	 * should be set up with the Reader (CSV input) and CsvPreference beforehand.
-	 * 
+	 *
 	 * @param tokenizer
 	 *            the tokenizer
 	 * @param preferences
@@ -78,10 +75,10 @@ public class CsvBeanReader extends AbstractCsvReader implements ICsvBeanReader {
 	public CsvBeanReader(final ITokenizer tokenizer, final CsvPreference preferences) {
 		super(tokenizer, preferences);
 	}
-	
+
 	/**
 	 * Instantiates the bean (or creates a proxy if it's an interface).
-	 * 
+	 *
 	 * @param clazz
 	 *            the bean class to instantiate (a proxy will be created if an interface is supplied), using the default
 	 *            (no argument) constructor
@@ -114,13 +111,13 @@ public class CsvBeanReader extends AbstractCsvReader implements ICsvBeanReader {
 				throw new SuperCsvReflectionException("error instantiating bean", e);
 			}
 		}
-		
+
 		return bean;
 	}
-	
+
 	/**
 	 * Invokes the setter on the bean with the supplied value.
-	 * 
+	 *
 	 * @param bean
 	 *            the bean
 	 * @param setMethod
@@ -139,59 +136,59 @@ public class CsvBeanReader extends AbstractCsvReader implements ICsvBeanReader {
 			throw new SuperCsvReflectionException(String.format("error invoking method %s()", setMethod.getName()), e);
 		}
 	}
-	
+
 	/**
 	 * Populates the bean by mapping the processed columns to the fields of the bean.
-	 * 
+	 *
 	 * @param resultBean
 	 *            the bean to populate
 	 * @param nameMapping
 	 *            the name mappings
 	 * @return the populated bean
-	 * @throws SuperCsvReflectionException
+	 * @throws org.supercsv.exception.SuperCsvReflectionException
 	 *             if there was a reflection exception while populating the bean
 	 */
 	private <T> T populateBean(final T resultBean, final String[] nameMapping) {
-		
+
 		// map each column to its associated field on the bean
 		for( int i = 0; i < nameMapping.length; i++ ) {
-			
+
 			final Object fieldValue = processedColumns.get(i);
-			
+
 			// don't call a set-method in the bean if there is no name mapping for the column or no result to store
 			if( nameMapping[i] == null || fieldValue == null ) {
 				continue;
 			}
-			
+
 			// invoke the setter on the bean
 			Method setMethod = cache.getSetMethod(resultBean, nameMapping[i], fieldValue.getClass());
 			invokeSetter(resultBean, setMethod, fieldValue);
-			
+
 		}
-		
+
 		return resultBean;
 	}
-	
+
 	/**
 	 * {@inheritDoc}
 	 */
 	public <T> T read(final Class<T> clazz, final String... nameMapping) throws IOException {
-		
+
 		if( clazz == null ) {
 			throw new NullPointerException("clazz should not be null");
 		} else if( nameMapping == null ) {
 			throw new NullPointerException("nameMapping should not be null");
 		}
-		
+
 		return readIntoBean(instantiateBean(clazz), nameMapping, null);
 	}
-	
+
 	/**
 	 * {@inheritDoc}
 	 */
 	public <T> T read(final Class<T> clazz, final String[] nameMapping, final CellProcessor... processors)
 		throws IOException {
-		
+
 		if( clazz == null ) {
 			throw new NullPointerException("clazz should not be null");
 		} else if( nameMapping == null ) {
@@ -199,24 +196,24 @@ public class CsvBeanReader extends AbstractCsvReader implements ICsvBeanReader {
 		} else if( processors == null ) {
 			throw new NullPointerException("processors should not be null");
 		}
-		
+
 		return readIntoBean(instantiateBean(clazz), nameMapping, processors);
 	}
-	
+
 	/**
 	 * {@inheritDoc}
 	 */
 	public <T> T read(final T bean, final String... nameMapping) throws IOException {
-		
+
 		if( bean == null ) {
 			throw new NullPointerException("bean should not be null");
 		} else if( nameMapping == null ) {
 			throw new NullPointerException("nameMapping should not be null");
 		}
-		
+
 		return readIntoBean(bean, nameMapping, null);
 	}
-	
+
 	/**
 	 * {@inheritDoc}
 	 */
@@ -228,14 +225,14 @@ public class CsvBeanReader extends AbstractCsvReader implements ICsvBeanReader {
 		} else if( processors == null ) {
 			throw new NullPointerException("processors should not be null");
 		}
-		
+
 		return readIntoBean(bean, nameMapping, processors);
 	}
-	
+
 	/**
 	 * Reads a row of a CSV file and populates the bean, using the supplied name mapping to map column values to the
 	 * appropriate fields. If processors are supplied then they are used, otherwise the raw String values will be used.
-	 * 
+	 *
 	 * @param bean
 	 *            the bean to populate
 	 * @param nameMapping
@@ -245,20 +242,20 @@ public class CsvBeanReader extends AbstractCsvReader implements ICsvBeanReader {
 	 * @return the populated bean, or null if EOF was reached
 	 * @throws IllegalArgumentException
 	 *             if nameMapping.length != number of CSV columns read
-	 * @throws IOException
+	 * @throws java.io.IOException
 	 *             if an I/O error occurred
 	 * @throws NullPointerException
 	 *             if bean or nameMapping are null
-	 * @throws SuperCsvConstraintViolationException
+	 * @throws org.supercsv.exception.SuperCsvConstraintViolationException
 	 *             if a CellProcessor constraint failed
-	 * @throws SuperCsvException
+	 * @throws org.supercsv.exception.SuperCsvException
 	 *             if there was a general exception while reading/processing
-	 * @throws SuperCsvReflectionException
+	 * @throws org.supercsv.exception.SuperCsvReflectionException
 	 *             if there was an reflection exception while mapping the values to the bean
 	 */
 	private <T> T readIntoBean(final T bean, final String[] nameMapping, final CellProcessor[] processors)
 		throws IOException {
-		
+
 		if( readRow() ) {
 			if( nameMapping.length != length() ) {
 				throw new IllegalArgumentException(String.format(
@@ -266,18 +263,18 @@ public class CsvBeanReader extends AbstractCsvReader implements ICsvBeanReader {
 						+ "should be the same size (nameMapping length = %d, columns = %d)", nameMapping.length,
 					length()));
 			}
-			
+
 			if( processors == null ) {
 				processedColumns.clear();
 				processedColumns.addAll(getColumns());
 			} else {
 				executeProcessors(processedColumns, processors);
 			}
-			
+
 			return populateBean(bean, nameMapping);
 		}
-		
+
 		return null; // EOF
 	}
-	
+
 }

--- a/super-csv/src/main/java/org/supercsv/io/Tokenizer.java
+++ b/super-csv/src/main/java/org/supercsv/io/Tokenizer.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2007 Kasper B. Graversen
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,57 +18,58 @@ package org.supercsv.io;
 import java.io.IOException;
 import java.io.Reader;
 import java.util.List;
-
 import org.supercsv.comment.CommentMatcher;
 import org.supercsv.exception.SuperCsvException;
 import org.supercsv.prefs.CsvPreference;
 
 /**
  * Reads the CSV file, line by line. If you want the line-reading functionality of this class, but want to define your
- * own implementation of {@link #readColumns(List)}, then consider writing your own Tokenizer by extending
+ * own implementation of {@link #readColumns(java.util.List)}, then consider writing your own Tokenizer by extending
  * AbstractTokenizer.
- * 
+ *
  * @author Kasper B. Graversen
  * @author James Bassett
  * @author Pietro Aragona
  */
 public class Tokenizer extends AbstractTokenizer {
-	
+
 	private static final char NEWLINE = '\n';
-	
+
 	private static final char SPACE = ' ';
-	
+
 	private final StringBuilder currentColumn = new StringBuilder();
-	
+
 	/* the raw, untokenized CSV row (may span multiple lines) */
 	private final StringBuilder currentRow = new StringBuilder();
-	
+
 	private final char quoteChar;
-	
-	private final int delimiterChar;
-	
+
+	private final String delimiterSymbols;
+
+	private final int delimiterSymbolsLength;
+
 	private final boolean surroundingSpacesNeedQuotes;
-	
+
 	private final boolean ignoreEmptyLines;
-	
+
 	private final CommentMatcher commentMatcher;
 
 	private final int maxLinesPerRow;
-	
+
 	private final EmptyColumnParsing emptyColumnParsing;
 
 	private final char quoteEscapeChar;
-	
+
 	/**
 	 * Enumeration of tokenizer states. QUOTE_MODE is activated between quotes.
 	 */
 	private enum TokenizerState {
 		NORMAL, QUOTE_MODE;
 	}
-	
+
 	/**
 	 * Constructs a new <tt>Tokenizer</tt>, which reads the CSV file, line by line.
-	 * 
+	 *
 	 * @param reader
 	 *            the reader
 	 * @param preferences
@@ -79,7 +80,8 @@ public class Tokenizer extends AbstractTokenizer {
 	public Tokenizer(final Reader reader, final CsvPreference preferences) {
 		super(reader, preferences);
 		this.quoteChar = preferences.getQuoteChar();
-		this.delimiterChar = preferences.getDelimiterChar();
+		this.delimiterSymbols = preferences.getDelimiterSymbols();
+		this.delimiterSymbolsLength = delimiterSymbols.length();
 		this.surroundingSpacesNeedQuotes = preferences.isSurroundingSpacesNeedQuotes();
 		this.ignoreEmptyLines = preferences.isIgnoreEmptyLines();
 		this.commentMatcher = preferences.getCommentMatcher();
@@ -87,21 +89,21 @@ public class Tokenizer extends AbstractTokenizer {
 		this.emptyColumnParsing = preferences.getEmptyColumnParsing();
 		this.quoteEscapeChar = preferences.getQuoteEscapeChar();
 	}
-	
+
 	/**
 	 * {@inheritDoc}
 	 */
 	public boolean readColumns(final List<String> columns) throws IOException {
-		
+
 		if( columns == null ) {
 			throw new NullPointerException("columns should not be null");
 		}
-		
+
 		// clear the reusable List and StringBuilders
 		columns.clear();
 		currentColumn.setLength(0);
 		currentRow.setLength(0);
-		
+
 		// read a line (ignoring empty lines/comments if necessary)
 		String line;
 		do {
@@ -111,10 +113,10 @@ public class Tokenizer extends AbstractTokenizer {
 			}
 		}
 		while( ignoreEmptyLines && line.length() == 0 || (commentMatcher != null && commentMatcher.isComment(line)) );
-		
+
 		// update the untokenized CSV row
 		currentRow.append(line);
-		
+
 		// process each character in the line, catering for surrounding quotes (QUOTE_MODE)
 		TokenizerState state = TokenizerState.NORMAL;
 		int quoteScopeStartingLine = -1; // the line number where a potential multi-line cell starts
@@ -122,7 +124,7 @@ public class Tokenizer extends AbstractTokenizer {
 		int charIndex = 0;
 		while( true ) {
 			boolean endOfLineReached = charIndex == line.length();
-			
+
 			if( endOfLineReached )
 			{
 				if( TokenizerState.NORMAL.equals(state) ) {
@@ -145,7 +147,7 @@ public class Tokenizer extends AbstractTokenizer {
 					 */
 					currentColumn.append(NEWLINE);
 					currentRow.append(NEWLINE); // specific line terminator lost, \n will have to suffice
-					
+
 					charIndex = 0;
 
 					if (maxLinesPerRow > 0 && getLineNumber() - quoteScopeStartingLine + 1 >= maxLinesPerRow) {
@@ -170,68 +172,73 @@ public class Tokenizer extends AbstractTokenizer {
 									"unexpected end of file while reading quoted column beginning on line %d and ending on line %d",
 									quoteScopeStartingLine, getLineNumber()));
 					}
-					
+
 					currentRow.append(line); // update untokenized CSV row
-					
+
 				    if (line.length() == 0){
 				    	// consecutive newlines
                         continue;
 				    }
 				}
 			}
-			
+
 			final char c = line.charAt(charIndex);
-			
-			if( TokenizerState.NORMAL.equals(state) ) {
-				
+
+			if (TokenizerState.NORMAL.equals(state)) {
+
 				/*
 				 * NORMAL mode (not within quotes).
 				 */
-				
-				if( c == delimiterChar) {
+
+				boolean isSeparator = false;
+				if (c == delimiterSymbols.charAt(0)) {
+
+					isSeparator = line.length() >= charIndex + delimiterSymbolsLength && line.substring(charIndex, charIndex + delimiterSymbolsLength).equals(delimiterSymbols);
+					if (isSeparator) {
 					/*
 					 * Delimiter. Save the column (trim trailing space if required) then continue to next character.
 					 */
-					if( !surroundingSpacesNeedQuotes ) {
-						appendSpaces(currentColumn, potentialSpaces);
+						if( !surroundingSpacesNeedQuotes ) {
+							appendSpaces(currentColumn, potentialSpaces);
+						}
+						addColumn(columns, line, charIndex);
+						potentialSpaces = 0;
+						currentColumn.setLength(0);
+						charIndex += delimiterSymbolsLength - 1;
 					}
-					addColumn(columns, line, charIndex);
-					potentialSpaces = 0;
-					currentColumn.setLength(0);
-					
-				} else if( c == SPACE ) {
-					/*
-					 * Space. Remember it, then continue to next character.
-					 */
-					potentialSpaces++;
-					
 				}
-				else if( c == quoteChar ) {
-					/*
-					 * A single quote ("). Update to QUOTESCOPE (but don't save quote), then continue to next character.
-					 */
-					state = TokenizerState.QUOTE_MODE;
-					quoteScopeStartingLine = getLineNumber();
-					
-					// cater for spaces before a quoted section (be lenient!)
-					if( !surroundingSpacesNeedQuotes || currentColumn.length() > 0 ) {
-						appendSpaces(currentColumn, potentialSpaces);
-					}
-					potentialSpaces = 0;
-					
-				} else {
-					/*
-					 * Just a normal character. Add any required spaces (but trim any leading spaces if surrounding
-					 * spaces need quotes), add the character, then continue to next character.
-					 */
-					if( !surroundingSpacesNeedQuotes || currentColumn.length() > 0 ) {
-						appendSpaces(currentColumn, potentialSpaces);
-					}
-					
-					potentialSpaces = 0;
-					currentColumn.append(c);
-				}
+				if (!isSeparator) {
+					if( c == SPACE ) {
+					    /*
+					    * Space. Remember it, then continue to next character.
+					    */
+					    potentialSpaces++;
 
+				    } else if (c == quoteChar) {
+					    /*
+					    * A single quote ("). Update to QUOTESCOPE (but don't save quote), then continue to next character.
+					    */
+						state = TokenizerState.QUOTE_MODE;
+						quoteScopeStartingLine = getLineNumber();
+
+						// cater for spaces before a quoted section (be lenient!)
+						if (!surroundingSpacesNeedQuotes || currentColumn.length() > 0) {
+							appendSpaces(currentColumn, potentialSpaces);
+						}
+						potentialSpaces = 0;
+					} else {
+					    /*
+					    * Just a normal character. Add any required spaces (but trim any leading spaces if surrounding
+					    * spaces need quotes), add the character, then continue to next character.
+					    */
+						if (!surroundingSpacesNeedQuotes || currentColumn.length() > 0) {
+							appendSpaces(currentColumn, potentialSpaces);
+						}
+
+						potentialSpaces = 0;
+						currentColumn.append(c);
+					}
+				}
 			} else {
 
 				/*
@@ -273,7 +280,8 @@ public class Tokenizer extends AbstractTokenizer {
 						 */
 						currentColumn.append(c);
 					}
-				} else if( c == quoteChar ) {
+				}
+				else if( c == quoteChar ) {
 
 					/*
 					 * A single quote ("). Update to NORMAL (but don't save quote), then continue to next character.
@@ -299,20 +307,20 @@ public class Tokenizer extends AbstractTokenizer {
 					currentColumn.append(c);
 				}
 			}
-			
+
 			charIndex++; // read next char of the line
 		}
 	}
 /**
  * Adds the currentColumn to columns list managing the case with currentColumn.length() == 0
  * It was introduced to manage the emptyColumnParsing.
- * 
+ *
  * @param columns
  * @param line
  * @param charIndex
  */
 	private void addColumn(final List<String> columns, String line, int charIndex) {
-		
+
 		if(currentColumn.length() > 0){
 			columns.add(currentColumn.toString());
 		}
@@ -324,10 +332,10 @@ public class Tokenizer extends AbstractTokenizer {
 			columns.add(noValue);
 		}
 	}
-	
+
 	/**
 	 * Appends the required number of spaces to the StringBuilder.
-	 * 
+	 *
 	 * @param sb
 	 *            the StringBuilder
 	 * @param spaces
@@ -338,7 +346,7 @@ public class Tokenizer extends AbstractTokenizer {
 			sb.append(SPACE);
 		}
 	}
-	
+
 	/**
 	 * {@inheritDoc}
 	 */

--- a/super-csv/src/main/java/org/supercsv/prefs/CsvPreference.java
+++ b/super-csv/src/main/java/org/supercsv/prefs/CsvPreference.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2007 Kasper B. Graversen
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -96,61 +96,61 @@ import org.supercsv.quote.QuoteMode;
  * <li>ignoring empty lines (enabled by default)</li>
  * <li>setting the maximum number of lines a row of CSV can span (useful for debugging files with mismatched quotes)</li>
  * </ul>
- * 
+ *
  * @author Kasper B. Graversen
  * @author James Bassett
  * @author Pietro Aragona
  */
 public final class CsvPreference {
-	
+
 	/**
 	 * Ready to use configuration that should cover 99% of all usages.
 	 */
-	public static final CsvPreference STANDARD_PREFERENCE = new CsvPreference.Builder('"', ',', "\r\n").build();
-	
+	public static final CsvPreference STANDARD_PREFERENCE = new CsvPreference.Builder('"', ",", "\r\n").build();
+
 	/**
 	 * Ready to use configuration for Windows Excel exported CSV files.
 	 */
-	public static final CsvPreference EXCEL_PREFERENCE = new CsvPreference.Builder('"', ',', "\n").build();
-	
+	public static final CsvPreference EXCEL_PREFERENCE = new CsvPreference.Builder('"', ",", "\n").build();
+
 	/**
 	 * Ready to use configuration for north European excel CSV files (columns are separated by ";" instead of ",")
 	 */
-	public static final CsvPreference EXCEL_NORTH_EUROPE_PREFERENCE = new CsvPreference.Builder('"', ';', "\n").build();
-	
+	public static final CsvPreference EXCEL_NORTH_EUROPE_PREFERENCE = new CsvPreference.Builder('"', ";", "\n").build();
+
 	/**
 	 * Ready to use configuration for tab-delimited files.
 	 */
-	public static final CsvPreference TAB_PREFERENCE = new CsvPreference.Builder('"', '\t', "\n").build();
-	
+	public static final CsvPreference TAB_PREFERENCE = new CsvPreference.Builder('"', "\t", "\n").build();
+
 	private final char quoteChar;
-	
-	private final int delimiterChar;
-	
+
+	private final String delimiterSymbols;
+
 	private final String endOfLineSymbols;
-	
+
 	private final boolean surroundingSpacesNeedQuotes;
-	
+
 	private final boolean ignoreEmptyLines;
-	
+
 	private final CsvEncoder encoder;
-	
+
 	private final QuoteMode quoteMode;
-	
+
 	private final CommentMatcher commentMatcher;
-	
+
 	private int maxLinesPerRow = 0;
-	
+
 	private final EmptyColumnParsing emptyColumnParsing;
 
 	private final char quoteEscapeChar;
-	
+
 	/**
 	 * Constructs a new <tt>CsvPreference</tt> from a Builder.
 	 */
 	private CsvPreference(Builder builder) {
 		this.quoteChar = builder.quoteChar;
-		this.delimiterChar = builder.delimiterChar;
+		this.delimiterSymbols = builder.delimiterSymbols;
 		this.endOfLineSymbols = builder.endOfLineSymbols;
 		this.surroundingSpacesNeedQuotes = builder.surroundingSpacesNeedQuotes;
 		this.ignoreEmptyLines = builder.ignoreEmptyLines;
@@ -161,79 +161,79 @@ public final class CsvPreference {
 		this.emptyColumnParsing = builder.emptyColumnParsing;
 		this.quoteEscapeChar = builder.quoteEscapeChar;
 	}
-	
+
 	/**
 	 * Returns the delimiter character
-	 * 
+	 *
 	 * @return the delimiter character
 	 */
-	public int getDelimiterChar() {
-		return delimiterChar;
+	public String getDelimiterSymbols() {
+		return delimiterSymbols;
 	}
-	
+
 	/**
 	 * Returns the end of line symbols
-	 * 
+	 *
 	 * @return the end of line symbols
 	 */
 	public String getEndOfLineSymbols() {
 		return endOfLineSymbols;
 	}
-	
+
 	/**
 	 * Returns the quote character
-	 * 
+	 *
 	 * @return the quote character
 	 */
 	public char getQuoteChar() {
 		return quoteChar;
 	}
-	
+
 	/**
 	 * Returns the surroundingSpacesNeedQuotes flag.
-	 * 
+	 *
 	 * @return the surroundingSpacesNeedQuotes flag
 	 */
 	public boolean isSurroundingSpacesNeedQuotes() {
 		return surroundingSpacesNeedQuotes;
 	}
-	
+
 	/**
 	 * Returns the ignoreEmptyLines flag.
-	 * 
+	 *
 	 * @return the ignoreEmptyLines flag
 	 */
 	public boolean isIgnoreEmptyLines() {
 		return ignoreEmptyLines;
 	}
-	
+
 	/**
 	 * Returns the CSV encoder.
-	 * 
+	 *
 	 * @return the CSV encoder
 	 */
 	public CsvEncoder getEncoder() {
 		return encoder;
 	}
-	
+
 	/**
 	 * Returns the quote mode.
-	 * 
+	 *
 	 * @return the quote mode
 	 */
 	public QuoteMode getQuoteMode() {
 		return quoteMode;
 	}
-	
+
 	/**
 	 * Returns the comment matcher.
-	 * 
+	 *
 	 * @return the comment matcher
 	 */
 	public CommentMatcher getCommentMatcher() {
 		return commentMatcher;
 	}
-	
+
 	/**
 	 * Returns the maximum number of lines a row can span.
 	 *
@@ -242,14 +242,14 @@ public final class CsvPreference {
 	public int getMaxLinesPerRow() {
 		return maxLinesPerRow;
 	}
-	
+
 	/**
 	 * Returns the EmptyColumnParsing to determine whether empty String (i.e. "") should be read as empty string or as
 	 * null.
-	 * 
+	 *
 	 * @return the emptyColumnParsing
 	 */
-	
+
 	public EmptyColumnParsing getEmptyColumnParsing() {
 		return emptyColumnParsing;
 	}
@@ -268,39 +268,39 @@ public final class CsvPreference {
 	 * added in the future.
 	 */
 	public static class Builder {
-		
+
 		private final char quoteChar;
-		
-		private final int delimiterChar;
-		
+
+		private final String delimiterSymbols;
+
 		private final String endOfLineSymbols;
 
 		private boolean surroundingSpacesNeedQuotes = false;
-		
+
 		private boolean ignoreEmptyLines = true;
-		
+
 		private CsvEncoder encoder;
-		
+
 		private QuoteMode quoteMode;
-		
+
 		private CommentMatcher commentMatcher;
-		
+
 		private int maxLinesPerRow = 0;
-		
+
 		private EmptyColumnParsing emptyColumnParsing;
 
 		private char quoteEscapeChar;
-		
+
 		/**
 		 * Constructs a Builder with all of the values from an existing <tt>CsvPreference</tt> instance. Useful if you
 		 * want to base your preferences off one of the existing CsvPreference constants.
-		 * 
+		 *
 		 * @param preference
 		 *            the existing preference
 		 */
 		public Builder(final CsvPreference preference) {
 			this.quoteChar = preference.quoteChar;
-			this.delimiterChar = preference.delimiterChar;
+			this.delimiterSymbols = preference.delimiterSymbols;
 			this.endOfLineSymbols = preference.endOfLineSymbols;
 			this.surroundingSpacesNeedQuotes = preference.surroundingSpacesNeedQuotes;
 			this.ignoreEmptyLines = preference.ignoreEmptyLines;
@@ -311,41 +311,41 @@ public final class CsvPreference {
 			this.emptyColumnParsing = preference.emptyColumnParsing;
 			this.quoteEscapeChar = preference.quoteEscapeChar;
 		}
-		
+
 		/**
 		 * Constructs a Builder with the mandatory preference values.
-		 * 
+		 *
 		 * @param quoteChar
 		 *            matching pairs of this character are used to escape columns containing the delimiter
-		 * @param delimiterChar
-		 *            the character separating each column
+		 * @param delimiterSymbols
+		 *            the symbols separating each column
 		 * @param endOfLineSymbols
 		 *            one or more symbols terminating the line, e.g. "\n". Only used for writing.
 		 * @throws IllegalArgumentException
-		 *             if quoteChar and delimiterChar are the same character
+		 *             if quoteChar and delimiterSymbols are the same character
 		 * @throws NullPointerException
 		 *             if endOfLineSymbols is null
 		 */
-		public Builder(final char quoteChar, final int delimiterChar, final String endOfLineSymbols) {
-			if( quoteChar == delimiterChar ) {
+		public Builder(final char quoteChar, final String delimiterSymbols, final String endOfLineSymbols) {
+			if(delimiterSymbols.contains(""+quoteChar)) {
 				throw new IllegalArgumentException(String.format(
-					"quoteChar and delimiterChar must not be the same character: %c", quoteChar));
+					"quoteChar and delimiterSymbols must not be the same character: %c", quoteChar));
 			} else if( endOfLineSymbols == null ) {
 				throw new NullPointerException("endOfLineSymbols should not be null");
 			}
 			this.quoteChar = quoteChar;
-			this.delimiterChar = delimiterChar;
+			this.delimiterSymbols = delimiterSymbols;
 			this.endOfLineSymbols = endOfLineSymbols;
 
 			// by default (RFC-spec) the quoteEscapeChar is the quoteChar
 			this.quoteEscapeChar = quoteChar;
 		}
-		
+
 		/**
 		 * Flag indicating whether spaces at the beginning or end of a cell should be ignored if they're not surrounded
 		 * by quotes (applicable to both reading and writing CSV). The default is <tt>false</tt>, as spaces
 		 * "are considered part of a field and should not be ignored" according to RFC 4180.
-		 * 
+		 *
 		 * @since 2.0.0
 		 * @param surroundingSpacesNeedQuotes
 		 *            flag indicating whether spaces at the beginning or end of a cell should be ignored if they're not
@@ -356,11 +356,11 @@ public final class CsvPreference {
 			this.surroundingSpacesNeedQuotes = surroundingSpacesNeedQuotes;
 			return this;
 		}
-		
+
 		/**
 		 * Flag indicating whether empty lines (i.e. containing only end of line symbols) should be ignored. The default
 		 * is <tt>true</tt>.
-		 * 
+		 *
 		 * @since 2.2.1
 		 * @param ignoreEmptyLines
 		 *            flag indicating whether empty lines should be ignored
@@ -370,12 +370,12 @@ public final class CsvPreference {
 			this.ignoreEmptyLines = ignoreEmptyLines;
 			return this;
 		}
-		
+
 		/**
 		 * Enables the skipping of comments. You can supply your own comment matcher or use one of the predefined ones:
 		 * {@link org.supercsv.comment.CommentStartsWith CommentStartsWith} or
 		 * {@link org.supercsv.comment.CommentMatches CommentMatches}
-		 * 
+		 *
 		 * @since 2.1.0
 		 * @param commentMatcher
 		 *            the comment matcher to use
@@ -390,10 +390,10 @@ public final class CsvPreference {
 			this.commentMatcher = commentMatcher;
 			return this;
 		}
-		
+
 		/**
 		 * Uses a custom CsvEncoder to escape CSV for writing.
-		 * 
+		 *
 		 * @since 2.1.0
 		 * @param encoder
 		 *            the custom encoder
@@ -408,13 +408,13 @@ public final class CsvPreference {
 			this.encoder = encoder;
 			return this;
 		}
-		
+
 		/**
 		 * Uses a custom QuoteMode to determine if surrounding quotes should be applied when writing (only applicable if
 		 * a column doesn't contain any special characters and wouldn't otherwise be quoted). You can supply your own
 		 * quote mode or use one of the predefined ones: {@link org.supercsv.quote.AlwaysQuoteMode AlwaysQuoteMode} or
 		 * {@link org.supercsv.quote.ColumnQuoteMode ColumnQuoteMode}
-		 * 
+		 *
 		 * @since 2.1.0
 		 * @param quoteMode
 		 *            the quote mode
@@ -429,14 +429,14 @@ public final class CsvPreference {
 			this.quoteMode = quoteMode;
 			return this;
 		}
-		
+
 		/**
 		 * The maximum number of lines that a row can span before an exception is thrown (only applicable when reading
 		 * CSV). This option allows CSV readers to fail fast when encountering CSV with mismatching quotes - the normal
 		 * behaviour would be to continue reading until the matching quote is found, which could potentially mean
 		 * reading the whole file (and exhausting all available memory). Zero or a negative value will disable this
 		 * option. The default is <tt>0</tt>.
-		 * 
+		 *
 		 * @since 2.4.0
 		 * @param maxLinesPerRow
 		 *            the maximum number of lines a row can span before an exception is thrown
@@ -446,7 +446,7 @@ public final class CsvPreference {
 			this.maxLinesPerRow = maxLinesPerRow;
 			return this;
 		}
-		
+
 		/**
 		 * Uses an EmptyColumnParsing to determine whether empty String (i.e. "") should be read as empty string instead as null.
 		 * The default is <tt>ParseEmptyColumnsAsNull</tt>.
@@ -467,7 +467,7 @@ public final class CsvPreference {
 		/**
 		 * Value indicating the character to use for escaping a quote char.  The default value is
 		 * the quote char (which is a double-quote <tt>"</tt> character by default).  This value
-		 * must not be the same as <tt>delimiterChar</tt>
+		 * must not be contained in <tt>delimiterSymbols</tt>
 		 *
 		 * @since 2.5.0
 		 * @param quoteEscapeChar
@@ -478,35 +478,35 @@ public final class CsvPreference {
 			this.quoteEscapeChar = quoteEscapeChar;
 			return this;
 		}
-		
+
 		/**
 		 * Builds the CsvPreference instance.
-		 * 
+		 *
 		 * @return the immutable CsvPreference instance
 		 */
 		public CsvPreference build() {
-			
+
 			if( encoder == null ) {
 				encoder = new DefaultCsvEncoder();
 			}
-			
+
 			if( quoteMode == null ) {
 				quoteMode = new NormalQuoteMode();
 			}
-			
+
 			if( emptyColumnParsing == null ) {
 				emptyColumnParsing = EmptyColumnParsing.ParseEmptyColumnsAsNull;
 			}
 
-			if( quoteEscapeChar == delimiterChar ) {
+			if(delimiterSymbols.contains(quoteEscapeChar + "")) {
 				throw new IllegalArgumentException(String.format(
-						"quoteEscapeChar and delimiterChar must not be the same character: %c",
+						"quoteEscapeChar and delimiterSymbols must not be the same character: %c",
 						quoteEscapeChar));
 			}
-			
+
 			return new CsvPreference(this);
 		}
-		
+
 	}
-	
+
 }

--- a/super-csv/src/test/java/org/supercsv/features/ReadingFeaturesTest.java
+++ b/super-csv/src/test/java/org/supercsv/features/ReadingFeaturesTest.java
@@ -15,6 +15,16 @@
  */
 package org.supercsv.features;
 
+import java.io.IOException;
+import java.io.StringReader;
+import java.lang.reflect.Method;
+import java.lang.reflect.Type;
+import java.math.BigDecimal;
+import java.math.MathContext;
+import java.text.DecimalFormatSymbols;
+import java.text.SimpleDateFormat;
+import java.util.List;
+import java.util.Map;
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -31,17 +41,6 @@ import org.supercsv.io.CsvMapReader;
 import org.supercsv.prefs.CsvPreference;
 import org.supercsv.prefs.CsvPreference.Builder;
 
-import java.io.IOException;
-import java.io.StringReader;
-import java.lang.reflect.Method;
-import java.lang.reflect.Type;
-import java.math.BigDecimal;
-import java.math.MathContext;
-import java.text.DecimalFormatSymbols;
-import java.text.SimpleDateFormat;
-import java.util.List;
-import java.util.Map;
-
 import static org.supercsv.prefs.CsvPreference.STANDARD_PREFERENCE;
 
 /**
@@ -51,246 +50,246 @@ import static org.supercsv.prefs.CsvPreference.STANDARD_PREFERENCE;
  * @author Michał Ziober
  */
 public class ReadingFeaturesTest {
-	
+
 	private DecimalFormatSymbols decimalFormatSymbols = DecimalFormatSymbols.getInstance();
-	
+
 	@Test
 	public void testCustomSeparator() throws IOException {
 		String csv = "John+Connor";
 		CellProcessor[] processors = { new NotNull(), new NotNull() };
-		
-		char customSeparator = '+';
+
+		String customSeparator = "+";
 		CsvPreference customPreference = new Builder('"', customSeparator, "").build();
 		CsvListReader listReader = new CsvListReader(new StringReader(csv), customPreference);
 		List<Object> result = listReader.read(processors);
-		
+
 		Assert.assertNotNull(result);
 		Assert.assertEquals(2, result.size());
 		Assert.assertEquals("John", result.get(0));
 		Assert.assertEquals("Connor", result.get(1));
 	}
-	
+
 	@Test
 	public void testCustomQuote() throws IOException {
 		String csv = "|John  Connor|";
 		CellProcessor[] processors = { new NotNull() };
-		
+
 		char customQuote = '|';
-		CsvPreference customPreference = new Builder(customQuote, ',', "").build();
+		CsvPreference customPreference = new Builder(customQuote, ",", "").build();
 		CsvListReader listReader = new CsvListReader(new StringReader(csv), customPreference);
 		List<Object> result = listReader.read(processors);
-		
+
 		Assert.assertNotNull(result);
 		Assert.assertEquals(1, result.size());
 		Assert.assertEquals("John  Connor", result.get(0));
 	}
-	
+
 	@Ignore
 	@Test
 	public void testCustomEscape() throws IOException {
 		throw new UnsupportedOperationException("Not implemented yet!");
 	}
-	
+
 	@Test
 	public void testCustomEOL() throws IOException {
 		String csv = "John,Connor\r>\n";
 		CellProcessor[] processors = { new NotNull(), new NotNull() };
-		
+
 		String customEndOfLine = "\r>\n";
-		CsvPreference customPreference = new Builder('"', ',', customEndOfLine).build();
+		CsvPreference customPreference = new Builder('"', ",", customEndOfLine).build();
 		CsvListReader listReader = new CsvListReader(new StringReader(csv), customPreference);
 		List<Object> result = listReader.read(processors);
-		
+
 		Assert.assertNotNull(result);
 		Assert.assertEquals(2, result.size());
 		Assert.assertEquals("John", result.get(0));
 		Assert.assertEquals("Connor", result.get(1));
 	}
-	
+
 	@Test
 	public void testNewLineInDelimitedField() throws IOException {
 		String csv = "\"Jo\nhn\",\"Con\nnor\"\n";
 		CellProcessor[] processors = { new NotNull(), new NotNull() };
-		
-		CsvPreference customPreference = new Builder('"', ',', "\n").build();
+
+		CsvPreference customPreference = new Builder('"', ",", "\n").build();
 		CsvListReader listReader = new CsvListReader(new StringReader(csv), customPreference);
 		List<Object> result = listReader.read(processors);
-		
+
 		Assert.assertNotNull(result);
 		Assert.assertEquals(2, result.size());
 		Assert.assertEquals("Jo\nhn", result.get(0));
 		Assert.assertEquals("Con\nnor", result.get(1));
 	}
-	
+
 	@Test
 	public void testEscapedQuoteInQuotedField() throws IOException {
 		String csv = "\"Joh\"\"n\",\"Con\"\"nor\"";
 		CellProcessor[] processors = { new NotNull(), new NotNull() };
-		
-		CsvPreference customPreference = new Builder('"', ',', "").build();
+
+		CsvPreference customPreference = new Builder('"', ",", "").build();
 		CsvListReader listReader = new CsvListReader(new StringReader(csv), customPreference);
 		List<Object> result = listReader.read(processors);
-		
+
 		Assert.assertNotNull(result);
 		Assert.assertEquals(2, result.size());
 		Assert.assertEquals("Joh\"n", result.get(0));
 		Assert.assertEquals("Con\"nor", result.get(1));
 	}
-	
+
 	@Ignore
 	@Test
 	public void testDifferentEscapeAndQuote() throws IOException {
 		throw new UnsupportedOperationException("Not implemented yet!");
 	}
-	
+
 	@Test
 	public void testDealWithLeadingTrailingWhitespace() throws IOException {
 		String csv = "     John    ,     Connor   ";
 		CellProcessor[] processors = { new Trim(), new Trim() };
-		
+
 		char customQuote = '"';
-		CsvPreference customPreference = new Builder(customQuote, ',', "").build();
+		CsvPreference customPreference = new Builder(customQuote, ",", "").build();
 		CsvListReader listReader = new CsvListReader(new StringReader(csv), customPreference);
 		List<Object> result = listReader.read(processors);
-		
+
 		Assert.assertNotNull(result);
 		Assert.assertEquals(2, result.size());
 		Assert.assertEquals("John", result.get(0));
 		Assert.assertEquals("Connor", result.get(1));
 	}
-	
+
 	@Test
 	public void testGetByColumnIndex() throws IOException {
 		String csv = "John,Connor";
-		
+
 		CsvListReader listReader = new CsvListReader(new StringReader(csv), STANDARD_PREFERENCE);
 		List<String> line = listReader.read();
-		
+
 		Assert.assertNotNull(line);
 		Assert.assertEquals(2, line.size());
 		Assert.assertEquals("John", line.get(0));
 		Assert.assertEquals("Connor", line.get(1));
 	}
-	
+
 	@Test
 	public void testGetByColumnName() throws IOException {
 		String csv = "John,Connor";
 		String[] mapping = { "firstName", "lastName" };
-		
+
 		CsvMapReader mapReader = new CsvMapReader(new StringReader(csv), STANDARD_PREFERENCE);
 		Map<String, String> line = mapReader.read(mapping);
-		
+
 		Assert.assertNotNull(line);
 		Assert.assertEquals(2, line.size());
 		Assert.assertEquals("John", line.get("firstName"));
 		Assert.assertEquals("Connor", line.get("lastName"));
 	}
-	
+
 	@Test
 	public void testReadSingleLineStreaming() throws IOException {
 		String csv = "Sarah,Connor\r\nJohn,Connor\r\nKyle,Reese";
-		
+
 		CsvListReader listReader = new CsvListReader(new StringReader(csv), STANDARD_PREFERENCE);
 		// skip first line
 		listReader.read();
 		// read second line
 		List<String> line = listReader.read();
-		
+
 		Assert.assertNotNull(line);
 		Assert.assertEquals(2, line.size());
 		Assert.assertEquals("John", line.get(0));
 		Assert.assertEquals("Connor", line.get(1));
 	}
-	
+
 	@Ignore
 	@Test
 	public void testReadAllLines() throws IOException {
 		throw new UnsupportedOperationException("'reader.readAll()' not implemented yet!");
 	}
-	
+
 	@Test
 	public void testSkipCommentLines() throws IOException {
 		String csv = "<!--Sarah,Connor-->\r\nJohn,Connor\r\n<!--Kyle,Reese-->";
-		
+
 		CsvPreference customPreference = new Builder(STANDARD_PREFERENCE).skipComments(new CommentMatches("<!--.*-->"))
 			.build();
 		CsvListReader listReader = new CsvListReader(new StringReader(csv), customPreference);
 		List<String> line = listReader.read();
 		List<String> emptyLine = listReader.read();
-		
+
 		Assert.assertNotNull(line);
 		Assert.assertEquals(2, line.size());
 		Assert.assertEquals("John", line.get(0));
 		Assert.assertEquals("Connor", line.get(1));
 		Assert.assertNull(emptyLine);
 	}
-	
+
 	@Test
 	public void testIgnoreEmptyLines() throws IOException {
 		String csv = "\r\n\n\nJohn,Connor\r\n\r\n";
-		
+
 		CsvListReader listReader = new CsvListReader(new StringReader(csv), STANDARD_PREFERENCE);
 		List<String> line = listReader.read();
 		List<String> emptyLine = listReader.read();
-		
+
 		Assert.assertNotNull(line);
 		Assert.assertEquals(2, line.size());
 		Assert.assertEquals("John", line.get(0));
 		Assert.assertEquals("Connor", line.get(1));
 		Assert.assertNull(emptyLine);
 	}
-	
+
 	@Ignore
 	@Test
 	public void testColumnIndexBasedMapping() throws IOException {
 		throw new UnsupportedOperationException("not implemented yet!");
 	}
-	
+
 	@Test
 	public void testColumnNameBasedMapping() throws IOException {
 		String csv = "Connor,John\r\n";
 		String[] mapping = { "lastName", "firstName" };
-		
+
 		CsvBeanReader beanReader = new CsvBeanReader(new StringReader(csv), STANDARD_PREFERENCE);
 		FeatureBean character = beanReader.read(FeatureBean.class, mapping);
-		
+
 		Assert.assertNotNull(character);
 		Assert.assertEquals("John", character.getFirstName());
 		Assert.assertEquals("Connor", character.getLastName());
 	}
-	
+
 	@Ignore
 	@Test
 	public void testSupportsAnnotations() throws IOException {
 		throw new UnsupportedOperationException("Annotations are not implemented yet!");
 	}
-	
+
 	@Test
 	public void testConvertsToPrimitives() throws IOException {
 		String csv = "Connor,John,16\r\n";
 		String[] mapping = { "lastName", "firstName", "age" };
 		CellProcessor[] processors = { new NotNull(), new NotNull(), new ParseInt() };
-		
+
 		CsvBeanReader beanReader = new CsvBeanReader(new StringReader(csv), STANDARD_PREFERENCE);
 		FeatureBean character = beanReader.read(FeatureBean.class, mapping, processors);
-		
+
 		Assert.assertNotNull(character);
 		Assert.assertEquals("John", character.getFirstName());
 		Assert.assertEquals("Connor", character.getLastName());
 		Assert.assertEquals(16, character.getAge());
 	}
-	
+
 	@Test
 	public void testConvertsToBasicObjects() throws Exception {
 		String csv = "Connor|John|16|1999-07-12|6" + decimalFormatSymbols.getDecimalSeparator() + "65\r\n";
 		String[] mapping = { "lastName", "firstName", "age", "birthDate", "savings" };
 		CellProcessor[] processors = { new NotNull(), new NotNull(), new ParseInt(), new ParseDate("yyyy-MM-dd"),
 			new ParseBigDecimal(decimalFormatSymbols) };
-		
-		CsvPreference customPreference = new Builder('"', '|', "\r\n").build();
+
+		CsvPreference customPreference = new Builder('"', "|", "\r\n").build();
 		CsvBeanReader beanReader = new CsvBeanReader(new StringReader(csv), customPreference);
 		FeatureBean character = beanReader.read(FeatureBean.class, mapping, processors);
-		
+
 		Assert.assertNotNull(character);
 		Assert.assertEquals("John", character.getFirstName());
 		Assert.assertEquals("Connor", character.getLastName());
@@ -298,18 +297,18 @@ public class ReadingFeaturesTest {
 		Assert.assertEquals(new SimpleDateFormat("yyyy-MM-dd").parse("1999-07-12"), character.getBirthDate());
 		Assert.assertEquals(new BigDecimal(6.65, new MathContext(3)), character.getSavings());
 	}
-	
+
 	@Test
 	public void testConverterSupport() throws Exception {
 		String csv = "Connor|John|16|1999-07-12|6" + decimalFormatSymbols.getDecimalSeparator() + "65\r\n";
 		String[] mapping = { "lastName", "firstName", "age", "birthDate", "savings" };
 		CellProcessor[] processors = { new NotNull(), new NotNull(), new ParseInt(), new ParseDate("yyyy-MM-dd"),
 			new ParseBigDecimal(decimalFormatSymbols) };
-		
-		CsvPreference customPreference = new Builder('"', '|', "\r\n").build();
+
+		CsvPreference customPreference = new Builder('"', "|", "\r\n").build();
 		CsvBeanReader beanReader = new CsvBeanReader(new StringReader(csv), customPreference);
 		FeatureBean character = beanReader.read(FeatureBean.class, mapping, processors);
-		
+
 		Assert.assertNotNull(character);
 		Assert.assertEquals("John", character.getFirstName());
 		Assert.assertEquals("Connor", character.getLastName());
@@ -317,20 +316,20 @@ public class ReadingFeaturesTest {
 		Assert.assertEquals(new SimpleDateFormat("yyyy-MM-dd").parse("1999-07-12"), character.getBirthDate());
 		Assert.assertEquals(new BigDecimal(6.65, new MathContext(3)), character.getSavings());
 	}
-	
+
 	@Test
 	public void testDateSupport() throws Exception {
 		String csv = "1999-07-12";
 		String[] mapping = { "birthDate" };
 		CellProcessor[] processors = { new ParseDate("yyyy-MM-dd") };
-		
+
 		CsvBeanReader beanReader = new CsvBeanReader(new StringReader(csv), STANDARD_PREFERENCE);
 		FeatureBean character = beanReader.read(FeatureBean.class, mapping, processors);
-		
+
 		Assert.assertNotNull(character);
 		Assert.assertEquals(new SimpleDateFormat("yyyy-MM-dd").parse("1999-07-12"), character.getBirthDate());
 	}
-	
+
 	@Test
 	public void testReturnsTypedBean() throws Exception {
 		int methodCounter = 0;
@@ -340,7 +339,7 @@ public class ReadingFeaturesTest {
 				try {
 					Type genericReturnType = method.getGenericReturnType();
 					Assert.assertNotNull(genericReturnType);
-					Assert.assertEquals("T", genericReturnType.getTypeName());
+//					Assert.assertEquals("T", genericReturnType.getTypeName());
 					methodCounter++;
 				}
 				catch(Exception e) {
@@ -350,18 +349,18 @@ public class ReadingFeaturesTest {
 		}
 		Assert.assertTrue(methodCounter > 0);
 	}
-	
+
 	@Test
 	public void testDeepConversion() {
 		Assert.assertNotNull("See org.supercsv.example.dozer.Reading class!");
 	}
-	
+
 	@Ignore
 	@Test
 	public void testSplitCellToMultipleProperties() {
 		throw new UnsupportedOperationException("Not implemented yet!");
 	}
-	
+
 	@Ignore
 	@Test
 	public void testJoinMultipleCellsIntoOneProperty() {

--- a/super-csv/src/test/java/org/supercsv/features/ReadingFeaturesTest.java
+++ b/super-csv/src/test/java/org/supercsv/features/ReadingFeaturesTest.java
@@ -339,7 +339,7 @@ public class ReadingFeaturesTest {
 				try {
 					Type genericReturnType = method.getGenericReturnType();
 					Assert.assertNotNull(genericReturnType);
-//					Assert.assertEquals("T", genericReturnType.getTypeName());
+					Assert.assertEquals("T", genericReturnType.getTypeName());
 					methodCounter++;
 				}
 				catch(Exception e) {

--- a/super-csv/src/test/java/org/supercsv/features/WritingFeaturesTest.java
+++ b/super-csv/src/test/java/org/supercsv/features/WritingFeaturesTest.java
@@ -15,6 +15,15 @@
  */
 package org.supercsv.features;
 
+import java.io.IOException;
+import java.io.StringWriter;
+import java.math.BigDecimal;
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.Collections;
+import java.util.List;
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -29,16 +38,6 @@ import org.supercsv.io.CsvMapWriter;
 import org.supercsv.prefs.CsvPreference;
 import org.supercsv.prefs.CsvPreference.Builder;
 
-import java.io.IOException;
-import java.io.StringWriter;
-import java.math.BigDecimal;
-import java.text.DecimalFormat;
-import java.text.DecimalFormatSymbols;
-import java.util.Arrays;
-import java.util.Calendar;
-import java.util.Collections;
-import java.util.List;
-
 import static org.supercsv.prefs.CsvPreference.STANDARD_PREFERENCE;
 
 /**
@@ -48,95 +47,95 @@ import static org.supercsv.prefs.CsvPreference.STANDARD_PREFERENCE;
  * @author Michał Ziober
  */
 public class WritingFeaturesTest {
-	
+
 	@Test
 	public void testCustomSeparator() throws IOException {
 		List<String> data = Arrays.asList("John", "Connor");
 		CellProcessor[] processors = { new NotNull(), new NotNull() };
-		
-		char customSeparator = '+';
+
+		String customSeparator = "+";
 		CsvPreference customPreference = new Builder('"', customSeparator, "").build();
 		String result = writeToCsv(data, processors, customPreference);
-		
+
 		Assert.assertEquals("John+Connor", result);
 	}
-	
+
 	@Test
 	public void testCustomQuote() throws IOException {
 		List<String> data = Collections.singletonList("John \n Connor");
 		CellProcessor[] processors = { new NotNull() };
-		
+
 		char customQuote = '|';
-		CsvPreference customPreference = new Builder(customQuote, ',', "").build();
+		CsvPreference customPreference = new Builder(customQuote, ",", "").build();
 		String result = writeToCsv(data, processors, customPreference);
-		
+
 		Assert.assertEquals("|John  Connor|", result);
 	}
-	
+
 	@Ignore
 	@Test
 	public void testCustomEscape() throws IOException {
 		throw new UnsupportedOperationException("Not implemented yet!");
 	}
-	
+
 	@Test
 	public void testCustomEOL() throws IOException {
 		List<String> data = Collections.singletonList("John Connor");
 		CellProcessor[] processors = { new NotNull() };
-		
+
 		String customEndOfLine = ">\r\n";
-		CsvPreference customPreference = new Builder('"', ',', customEndOfLine).build();
+		CsvPreference customPreference = new Builder('"', ",", customEndOfLine).build();
 		String result = writeToCsv(data, processors, customPreference);
-		
+
 		Assert.assertEquals("John Connor>\r\n", result);
 	}
-	
+
 	@Test
 	public void testNewLineInDelimitedField() throws IOException {
 		List<String> data = Arrays.asList("Jo\nhn", "Con\nnor");
 		CellProcessor[] processors = { new NotNull(), new NotNull() };
-		
-		CsvPreference customPreference = new Builder('"', ',', "\n").build();
+
+		CsvPreference customPreference = new Builder('"', ",", "\n").build();
 		String result = writeToCsv(data, processors, customPreference);
-		
+
 		Assert.assertEquals("\"Jo\nhn\",\"Con\nnor\"\n", result);
 	}
-	
+
 	@Test
 	public void testEscapedQuoteInQuotedField() throws IOException {
 		List<String> data = Arrays.asList("Joh\"n", "Con\"nor");
 		CellProcessor[] processors = { new NotNull(), new NotNull() };
-		
-		CsvPreference customPreference = new Builder('"', ',', "").build();
+
+		CsvPreference customPreference = new Builder('"', ",", "").build();
 		String result = writeToCsv(data, processors, customPreference);
-		
+
 		Assert.assertEquals("\"Joh\"\"n\",\"Con\"\"nor\"", result);
 	}
-	
+
 	@Ignore
 	@Test
 	public void testDifferentEscapeAndQuote() throws IOException {
 		throw new UnsupportedOperationException("Not implemented yet!");
 	}
-	
+
 	@Test
 	public void testDealWithLeadingTrailingWhitespace() throws IOException {
 		List<String> data = Arrays.asList("     John   ", "   Connor     ");
 		CellProcessor[] processors = { new Trim(), new Trim() };
-		
+
 		char customQuote = '"';
-		CsvPreference customPreference = new Builder(customQuote, ',', "").surroundingSpacesNeedQuotes(false).build();
+		CsvPreference customPreference = new Builder(customQuote, ",", "").surroundingSpacesNeedQuotes(false).build();
 		String result = writeToCsv(data, processors, customPreference);
-		
+
 		Assert.assertEquals("John,Connor", result);
 	}
-	
+
 	@Ignore
 	@Test
 	public void testColumnIndexBasedMapping() throws IOException {
 		throw new UnsupportedOperationException("not implemented yet!");
 	}
-	
+
 	@Test
 	public void testColumnNameBasedMapping() throws IOException {
 		FeatureBean character = new FeatureBean("John", "Connor", 16);
@@ -145,131 +144,131 @@ public class WritingFeaturesTest {
 		CsvBeanWriter beanWriter = new CsvBeanWriter(writer, STANDARD_PREFERENCE);
 		beanWriter.write(character, mapping);
 		beanWriter.close();
-		
+
 		String csv = writer.toString();
 		Assert.assertNotNull(csv);
 		Assert.assertEquals("Connor,John\r\n", csv);
 	}
-	
+
 	@Ignore
 	@Test
 	public void testSupportsAnnotations() throws IOException {
 		throw new UnsupportedOperationException("Annotations are not implemented yet!");
 	}
-	
+
 	@Test
 	public void testConvertsToPrimitives() throws IOException {
 		FeatureBean character = new FeatureBean("John", "Connor", 16);
 		String[] mapping = { "lastName", "firstName", "age" };
-		
+
 		StringWriter writer = new StringWriter();
 		CsvBeanWriter beanWriter = new CsvBeanWriter(writer, STANDARD_PREFERENCE);
 		beanWriter.write(character, mapping);
 		beanWriter.close();
-		
+
 		String csv = writer.toString();
 		Assert.assertNotNull(csv);
 		Assert.assertEquals("Connor,John,16\r\n", csv);
 	}
-	
+
 	@Test
 	public void testConvertsToBasicObjects() throws IOException {
 		Calendar calendar = Calendar.getInstance();
 		calendar.set(Calendar.YEAR, 1999);
 		calendar.set(Calendar.MONTH, 6);
 		calendar.set(Calendar.DAY_OF_MONTH, 12);
-		
+
 		FeatureBean character = new FeatureBean("John", "Connor", 16);
 		character.setSavings(new BigDecimal(6.65));
 		character.setBirthDate(calendar.getTime());
-		
+
 		String[] mapping = { "lastName", "firstName", "age", "birthDate", "savings" };
 		DecimalFormat formatter = new DecimalFormat();
 		formatter.setDecimalFormatSymbols(DecimalFormatSymbols.getInstance());
 		CellProcessor[] processors = { new NotNull(), new NotNull(), new NotNull(), new FmtDate("yyyy-MM-dd"),
 			new FmtNumber(formatter) };
-		
+
 		StringWriter writer = new StringWriter();
-		CsvPreference customPreference = new Builder('"', '|', "\r\n").build();
+		CsvPreference customPreference = new Builder('"', "|", "\r\n").build();
 		CsvBeanWriter beanWriter = new CsvBeanWriter(writer, customPreference);
 		beanWriter.write(character, mapping, processors);
 		beanWriter.close();
-		
+
 		String csv = writer.toString();
 		Assert.assertNotNull(csv);
 		Assert.assertEquals("Connor|John|16|1999-07-12|" + formatter.format(character.getSavings()) + "\r\n", csv);
 	}
-	
+
 	@Test
 	public void testConverterSupport() throws IOException {
 		Calendar calendar = Calendar.getInstance();
 		calendar.set(Calendar.YEAR, 1999);
 		calendar.set(Calendar.MONTH, 6);
 		calendar.set(Calendar.DAY_OF_MONTH, 12);
-		
+
 		FeatureBean character = new FeatureBean("John", "Connor", 16);
 		character.setSavings(new BigDecimal(6.65));
 		character.setBirthDate(calendar.getTime());
-		
+
 		String[] mapping = { "lastName", "firstName", "age", "birthDate", "savings" };
 		DecimalFormat formatter = new DecimalFormat();
 		formatter.setDecimalFormatSymbols(DecimalFormatSymbols.getInstance());
 		CellProcessor[] processors = { new NotNull(), new NotNull(), new NotNull(), new FmtDate("yyyy-MM-dd"),
 			new FmtNumber(formatter) };
-		
+
 		StringWriter writer = new StringWriter();
-		CsvPreference customPreference = new Builder('"', '|', "\r\n").build();
+		CsvPreference customPreference = new Builder('"', "|", "\r\n").build();
 		CsvBeanWriter beanWriter = new CsvBeanWriter(writer, customPreference);
 		beanWriter.write(character, mapping, processors);
 		beanWriter.close();
-		
+
 		String csv = writer.toString();
 		Assert.assertNotNull(csv);
 		Assert.assertEquals("Connor|John|16|1999-07-12|" + formatter.format(character.getSavings()) + "\r\n", csv);
 	}
-	
+
 	@Test
 	public void testDateSupport() throws IOException {
 		Calendar calendar = Calendar.getInstance();
 		calendar.set(Calendar.YEAR, 1999);
 		calendar.set(Calendar.MONTH, 6);
 		calendar.set(Calendar.DAY_OF_MONTH, 12);
-		
+
 		FeatureBean character = new FeatureBean("John", "Connor", 16);
 		character.setBirthDate(calendar.getTime());
-		
+
 		String[] mapping = { "birthDate" };
 		DecimalFormat formatter = new DecimalFormat();
 		formatter.setDecimalFormatSymbols(DecimalFormatSymbols.getInstance());
 		CellProcessor[] processors = { new FmtDate("yyyy-MM-dd") };
-		
+
 		StringWriter writer = new StringWriter();
 		CsvBeanWriter beanWriter = new CsvBeanWriter(writer, STANDARD_PREFERENCE);
 		beanWriter.write(character, mapping, processors);
 		beanWriter.close();
-		
+
 		String csv = writer.toString();
 		Assert.assertNotNull(csv);
 		Assert.assertEquals("1999-07-12\r\n", csv);
 	}
-	
+
 	@Test
 	public void testDeepConversion() {
 		Assert.assertNotNull("See org.supercsv.example.dozer.Writing class!");
 	}
-	
+
 	@Ignore
 	@Test
 	public void testSplitCellToMultipleProperties() {
 		throw new UnsupportedOperationException("Not implemented yet!");
 	}
-	
+
 	@Ignore
 	@Test
 	public void testJoinMultipleCellsIntoOneProperty() {
 		throw new UnsupportedOperationException("Not implemented yet!");
 	}
-	
+
 	@Test
 	public void testWriteToWriter() throws IOException {
 		StringWriter writer = new StringWriter();
@@ -277,14 +276,14 @@ public class WritingFeaturesTest {
 		new CsvMapWriter(writer, STANDARD_PREFERENCE);
 		new CsvBeanWriter(writer, STANDARD_PREFERENCE);
 	}
-	
+
 	private String writeToCsv(List<String> data, CellProcessor[] processors, CsvPreference preference)
 		throws IOException {
 		StringWriter writer = new StringWriter();
 		CsvListWriter listWriter = new CsvListWriter(writer, preference);
 		listWriter.write(data, processors);
 		listWriter.close();
-		
+
 		return writer.toString();
 	}
 }

--- a/super-csv/src/test/java/org/supercsv/io/AbstractCsvWriterTest.java
+++ b/super-csv/src/test/java/org/supercsv/io/AbstractCsvWriterTest.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2007 Kasper B. Graversen
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -30,34 +30,34 @@ import org.supercsv.prefs.CsvPreference;
 
 /**
  * Tests AbstractCsvWriter.
- * 
+ *
  * @author Kasper B. Graversen
  * @author James Bassett
  */
 public class AbstractCsvWriterTest {
-	
+
 	private static final CsvPreference PREFS = CsvPreference.STANDARD_PREFERENCE;
 	private static final CsvPreference SURROUNDING_SPACES_REQUIRE_QUOTES_PREFS = new CsvPreference.Builder(
 		CsvPreference.STANDARD_PREFERENCE).surroundingSpacesNeedQuotes(true).build();
-	
+
 	private Writer writer;
-	
+
 	private AbstractCsvWriter abstractWriter;
 	private AbstractCsvWriter surroundingSpacesNeedQuotesAbstractWriter;
-	
+
 	/**
 	 * Implementation of AbstractCsvWriter for testing.
 	 */
 	static class MockCsvWriter extends AbstractCsvWriter {
-		
+
 		private CsvPreference preference;
-		
+
 		public MockCsvWriter(Writer writer, CsvPreference preference) {
 			super(writer, preference);
 			this.preference = preference;
 		}
 	}
-	
+
 	/**
 	 * Sets up the writer for the tests.
 	 */
@@ -67,7 +67,7 @@ public class AbstractCsvWriterTest {
 		abstractWriter = new MockCsvWriter(writer, PREFS);
 		surroundingSpacesNeedQuotesAbstractWriter = new MockCsvWriter(writer, SURROUNDING_SPACES_REQUIRE_QUOTES_PREFS);
 	}
-	
+
 	/**
 	 * Closes the writer after the test.
 	 */
@@ -76,7 +76,7 @@ public class AbstractCsvWriterTest {
 		abstractWriter.close();
 		surroundingSpacesNeedQuotesAbstractWriter.close();
 	}
-	
+
 	/**
 	 * Tests the writeHeader() method.
 	 */
@@ -84,16 +84,16 @@ public class AbstractCsvWriterTest {
 	public void testWriteHeader() throws IOException {
 		assertEquals(0, abstractWriter.getLineNumber());
 		assertEquals(0, abstractWriter.getRowNumber());
-		
+
 		abstractWriter.writeHeader(HEADER);
-		
+
 		assertEquals(1, abstractWriter.getLineNumber());
 		assertEquals(1, abstractWriter.getRowNumber());
-		
+
 		abstractWriter.flush();
 		assertEquals(HEADER_CSV + "\r\n", writer.toString());
 	}
-	
+
 	/**
 	 * Tests the writeComment() method.
 	 */
@@ -101,73 +101,73 @@ public class AbstractCsvWriterTest {
 	public void testWriteComment() throws IOException {
 		assertEquals(0, abstractWriter.getLineNumber());
 		assertEquals(0, abstractWriter.getRowNumber());
-		
+
 		final String comment = "#this is a comment";
 		abstractWriter.writeComment(comment);
 		assertEquals(1, abstractWriter.getLineNumber());
 		assertEquals(0, abstractWriter.getRowNumber());
-		
+
 		final String header = "this,is,the,header";
 		abstractWriter.writeHeader(header.split(","));
 		assertEquals(2, abstractWriter.getLineNumber());
 		assertEquals(1, abstractWriter.getRowNumber());
-		
+
 		abstractWriter.writeComment(comment);
 		assertEquals(3, abstractWriter.getLineNumber());
 		assertEquals(1, abstractWriter.getRowNumber());
-		
+
 		abstractWriter.writeHeader(header.split(","));
 		assertEquals(4, abstractWriter.getLineNumber());
 		assertEquals(2, abstractWriter.getRowNumber());
-		
+
 		abstractWriter.flush();
 		final String eol = PREFS.getEndOfLineSymbols();
 		final String expected = comment + eol + header + eol + comment + eol + header + eol;
 		assertEquals(expected, writer.toString());
 	}
-	
+
 	/**
 	 * Tests that all 3 variations of line terminators embedded in CSV are handled correctly (are replaced with the end
 	 * of line symbols and line number is incremented correctly). writeHeader() is used because it increments the line
 	 * number just like the write() methods exposed on concretes writers.
-	 * 
+	 *
 	 * @param csvWriter
 	 *            the CSV writer
 	 * @param prefs
 	 *            the preferences
-	 * @throws IOException
+	 * @throws java.io.IOException
 	 */
 	private void writeHeaderWithEmbeddedEndOfLineSymbols(final MockCsvWriter csvWriter) throws IOException {
-		
+
 		final String eolSymbols = csvWriter.preference.getEndOfLineSymbols();
-		
+
 		final String textWithNewline = "text that\nspans\nthree lines";
 		final String textWithCarriageReturn = "text that\rspans\rthree lines";
 		final String textWithCarriageAndNewline = "text that\r\nspans\r\nthree lines";
-		
+
 		final String expected = "\"text that" + eolSymbols + "spans" + eolSymbols + "three lines\"" + eolSymbols;
-		
+
 		// \n
 		csvWriter.writeHeader(textWithNewline);
 		csvWriter.flush();
 		assertEquals(expected, writer.toString());
 		assertEquals(3, csvWriter.getLineNumber());
 		assertEquals(1, csvWriter.getRowNumber());
-		
+
 		// \r
 		csvWriter.writeHeader(textWithCarriageReturn);
 		csvWriter.flush();
 		assertEquals(expected + expected, writer.toString());
 		assertEquals(6, csvWriter.getLineNumber());
 		assertEquals(2, csvWriter.getRowNumber());
-		
+
 		// \r\n
 		csvWriter.writeHeader(textWithCarriageAndNewline);
 		csvWriter.flush();
 		assertEquals(expected + expected + expected, writer.toString());
 		assertEquals(9, csvWriter.getLineNumber());
 		assertEquals(3, csvWriter.getRowNumber());
-		
+
 		// \r\n\n (checks that skipNewline only skips 1 newline)
 		csvWriter.writeHeader("\r\n\n");
 		csvWriter.flush();
@@ -175,10 +175,10 @@ public class AbstractCsvWriterTest {
 			writer.toString());
 		assertEquals(12, csvWriter.getLineNumber());
 		assertEquals(4, csvWriter.getRowNumber());
-		
+
 		csvWriter.close();
 	}
-	
+
 	/**
 	 * Tests the writeHeader() method with an embedded carriage return and newline (i.e. Windows).
 	 */
@@ -186,7 +186,7 @@ public class AbstractCsvWriterTest {
 	public void testWriteHeaderWithCarriageReturnNewline() throws IOException {
 		writeHeaderWithEmbeddedEndOfLineSymbols(new MockCsvWriter(writer, CsvPreference.STANDARD_PREFERENCE));
 	}
-	
+
 	/**
 	 * Tests the writeHeader() method with an embedded newline (i.e. Linux).
 	 */
@@ -194,16 +194,16 @@ public class AbstractCsvWriterTest {
 	public void testWriteHeaderWithNewline() throws IOException {
 		writeHeaderWithEmbeddedEndOfLineSymbols(new MockCsvWriter(writer, CsvPreference.EXCEL_PREFERENCE));
 	}
-	
+
 	/**
 	 * Tests the writeHeader() method with an embedded carriage return (i.e. Mac).
 	 */
 	@Test
 	public void testWriteHeaderWithCarriageReturn() throws IOException {
 		writeHeaderWithEmbeddedEndOfLineSymbols(new MockCsvWriter(writer,
-			new CsvPreference.Builder('"', ',', "\r").build()));
+			new CsvPreference.Builder('"', ",", "\r").build()));
 	}
-	
+
 	/**
 	 * Tests the writeComment() method with a null String.
 	 */
@@ -211,7 +211,7 @@ public class AbstractCsvWriterTest {
 	public void writeCommentWithNull() throws IOException {
 		abstractWriter.writeComment(null);
 	}
-	
+
 	/**
 	 * Tests the writeHeader() method with a null array.
 	 */
@@ -219,7 +219,7 @@ public class AbstractCsvWriterTest {
 	public void writeHeaderWithNull() throws IOException {
 		abstractWriter.writeHeader((String[]) null);
 	}
-	
+
 	/**
 	 * Tests the writeHeader() method with an empty array.
 	 */
@@ -227,7 +227,7 @@ public class AbstractCsvWriterTest {
 	public void writeHeaderWithEmptyArray() throws IOException {
 		abstractWriter.writeHeader(new String[] {});
 	}
-	
+
 	/**
 	 * Tests the constructor with a null writer.
 	 */
@@ -236,7 +236,7 @@ public class AbstractCsvWriterTest {
 	public void testConstructorWithNullWriter() {
 		new MockCsvWriter(null, PREFS);
 	}
-	
+
 	/**
 	 * Tests the constructor with a null preference.
 	 */

--- a/super-csv/src/test/java/org/supercsv/io/CsvMapWriterTest.java
+++ b/super-csv/src/test/java/org/supercsv/io/CsvMapWriterTest.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2007 Kasper B. Graversen
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -39,18 +39,18 @@ import org.supercsv.util.Util;
 
 /**
  * Tests the CsvMapWriter class.
- * 
+ *
  * @author James Bassett
  * @author Pietro Aragona
  */
 public class CsvMapWriterTest {
-	
+
 	private static final CsvPreference PREFS = CsvPreference.STANDARD_PREFERENCE;
-	
+
 	private Writer writer;
-	
+
 	private CsvMapWriter mapWriter;
-	
+
 	/**
 	 * Sets up the writer for the tests.
 	 */
@@ -59,7 +59,7 @@ public class CsvMapWriterTest {
 		writer = new StringWriter();
 		mapWriter = new CsvMapWriter(writer, PREFS);
 	}
-	
+
 	/**
 	 * Closes the map writer after the test.
 	 */
@@ -67,7 +67,7 @@ public class CsvMapWriterTest {
 	public void tearDown() throws IOException {
 		mapWriter.close();
 	}
-	
+
 	/**
 	 * Tests the constructor with a null writer.
 	 */
@@ -76,7 +76,7 @@ public class CsvMapWriterTest {
 	public void testConstructorWillNullWriter() {
 		new CsvMapWriter(null, PREFS);
 	}
-	
+
 	/**
 	 * Tests the constructor with a null CsvPreference.
 	 */
@@ -85,11 +85,11 @@ public class CsvMapWriterTest {
 	public void testConstructorWillNullPreference() {
 		new CsvMapWriter(writer, null);
 	}
-	
+
 	/**
 	 * Tests the write() method.
-	 * 
-	 * @throws IOException
+	 *
+	 * @throws java.io.IOException
 	 */
 	@Test
 	public void testWrite() throws IOException {
@@ -108,7 +108,7 @@ public class CsvMapWriterTest {
 		mapWriter.flush();
 		assertEquals(CSV_FILE, writer.toString());
 	}
-	
+
 	/**
 	 * Tests the write() method with processors.
 	 */
@@ -129,7 +129,7 @@ public class CsvMapWriterTest {
 		mapWriter.flush();
 		assertEquals(CSV_FILE, writer.toString());
 	}
-	
+
 	/**
 	 * Tests the write() method with a null map.
 	 */
@@ -137,7 +137,7 @@ public class CsvMapWriterTest {
 	public void testWriteWithNullMap() throws IOException {
 		mapWriter.write(null, HEADER);
 	}
-	
+
 	/**
 	 * Tests the write() method with a null name mapping array.
 	 */
@@ -145,7 +145,7 @@ public class CsvMapWriterTest {
 	public void testWriteWithNullNameMapping() throws IOException {
 		mapWriter.write(new HashMap<String, Object>(), (String[]) null);
 	}
-	
+
 	/**
 	 * Tests the write() method (with processors) with a null map.
 	 */
@@ -153,23 +153,23 @@ public class CsvMapWriterTest {
 	public void testWriteProcessorsWithNullMap() throws IOException {
 		mapWriter.write(null, HEADER, WRITE_PROCESSORS);
 	}
-	
+
 	/**
 	 * Tests the write() method (with processors) with a null name mapping array.
 	 */
 	@Test(expected = NullPointerException.class)
 	public void testWriteProcessorsWithNullNameMapping() throws IOException {
 		mapWriter.write(new HashMap<String, Object>(), null, WRITE_PROCESSORS);
-		
+
 	}
-	
+
 	/**
 	 * Tests the write() method (with processors) with a null cell processor array.
 	 */
 	@Test(expected = NullPointerException.class)
 	public void testWriteProcessorsWithNullProcessors() throws IOException {
 		mapWriter.write(new HashMap<String, Object>(), HEADER, null);
-		
+
 	}
-	
+
 }

--- a/super-csv/src/test/java/org/supercsv/io/CsvResultSetWriterTest.java
+++ b/super-csv/src/test/java/org/supercsv/io/CsvResultSetWriterTest.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2007 Kasper B. Graversen
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -42,25 +42,25 @@ import org.supercsv.prefs.CsvPreference;
 
 /**
  * Tests the CsvResultSetWriter class
- * 
+ *
  * @author SingularityFX
  * @author Pietro Aragona
  */
 public class CsvResultSetWriterTest {
-	
+
 	private static final CsvPreference PREFS = CsvPreference.STANDARD_PREFERENCE;
 	public static Object[][] TEST_DATA_VARIOUS_TYPES;
 	public static Object[][] TEST_DATA_STRINGS;
-	
+
 	private Writer writer;
 	private CsvResultSetWriter csvResultSetWriter;
-	
+
 	@BeforeClass
 	public static void beforeClass() {
 		TEST_DATA_VARIOUS_TYPES = setUpTestDataCustomerBeans();
 		TEST_DATA_STRINGS = setUpTestDataCustomerStringBeans();
 	}
-	
+
 	private static Object[][] setUpTestDataCustomerBeans() {
 		final Object[][] testData = new Object[10][11];
 		for( int i = 0; i < 10; i++ ) {
@@ -79,7 +79,7 @@ public class CsvResultSetWriterTest {
 		}
 		return testData;
 	}
-	
+
 	private static Object[][] setUpTestDataCustomerStringBeans() {
 		final Object[][] testData = new Object[10][11];
 		for( int i = 0; i < 10; i++ ) {
@@ -98,17 +98,17 @@ public class CsvResultSetWriterTest {
 		}
 		return testData;
 	}
-	
+
 	@Before
 	public void setUp() {
 		writer = new StringWriter();
 		csvResultSetWriter = new CsvResultSetWriter(writer, PREFS);
 	}
-	
+
 	/**
 	 * Tests writing ResultSet to a CSV file (no CellProcessors)
-	 * 
-	 * @throws SQLException
+	 *
+	 * @throws java.sql.SQLException
 	 */
 	@Test
 	public void testWrite() throws IOException, SQLException {
@@ -117,12 +117,12 @@ public class CsvResultSetWriterTest {
 		csvResultSetWriter.flush();
 		assertEquals(CSV_FILE, writer.toString());
 	}
-	
+
 	/**
 	 * Test writing ResultSet to a CSV file with CellProcessors
-	 * 
-	 * @throws IOException
-	 * @throws SQLException
+	 *
+	 * @throws java.io.IOException
+	 * @throws java.sql.SQLException
 	 */
 	@Test
 	public void testWriteWithProcessors() throws SQLException, IOException {
@@ -131,9 +131,9 @@ public class CsvResultSetWriterTest {
 		csvResultSetWriter.flush();
 		assertEquals(CSV_FILE, writer.toString());
 	}
-	
+
 	// Tests for NullPointerException follow
-	
+
 	/**
 	 * Tests the constructor with a null writer
 	 */
@@ -142,7 +142,7 @@ public class CsvResultSetWriterTest {
 	public void testConstructorWithNullWriter() {
 		new CsvResultSetWriter(null, PREFS);
 	}
-	
+
 	/**
 	 * Tests the constructor with a null CsvPreference
 	 */
@@ -151,47 +151,47 @@ public class CsvResultSetWriterTest {
 	public void testConstructorWithNullCsvPreference() {
 		new CsvResultSetWriter(writer, null);
 	}
-	
+
 	/**
 	 * Tests the write() method with null ResultSet
-	 * 
-	 * @throws SQLException
-	 * @throws IOException
+	 *
+	 * @throws java.sql.SQLException
+	 * @throws java.io.IOException
 	 */
 	@Test(expected = NullPointerException.class)
 	public void testWriteNullResultSet() throws SQLException, IOException {
 		csvResultSetWriter.write(null);
 	}
-	
+
 	/**
 	 * Test the write() method (with processors) with null ResultSet
-	 * 
-	 * @throws IOException
-	 * @throws SQLException
+	 *
+	 * @throws java.io.IOException
+	 * @throws java.sql.SQLException
 	 */
 	@Test(expected = NullPointerException.class)
 	public void testWriteWithProcessorsNullResultSet() throws SQLException, IOException {
 		csvResultSetWriter.write(null, WRITE_PROCESSORS);
 	}
-	
+
 	/**
 	 * Tests the write() method (with processors) with a null cell processor array
-	 * 
-	 * @throws IOException
-	 * @throws SQLException
+	 *
+	 * @throws java.io.IOException
+	 * @throws java.sql.SQLException
 	 */
 	@Test(expected = NullPointerException.class)
 	public void testWriteNullProcessors() throws SQLException, IOException {
-		
+
 		final ResultSet resultSet = new ResultSetMock(TEST_DATA_VARIOUS_TYPES, HEADER);
 		csvResultSetWriter.write(resultSet, null);
 	}
-	
+
 	/**
 	 * Test that row/line numbers reported during exception are determined correctly
-	 * 
-	 * @throws IOException
-	 * @throws SQLException
+	 *
+	 * @throws java.io.IOException
+	 * @throws java.sql.SQLException
 	 */
 	@Test(expected = SuperCsvCellProcessorException.class)
 	public void testRowLineNumberCorrectness() throws SQLException, IOException {

--- a/super-csv/src/test/java/org/supercsv/io/TokenizerEscapingTest.java
+++ b/super-csv/src/test/java/org/supercsv/io/TokenizerEscapingTest.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2007 Kasper B. Graversen
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,18 +15,17 @@
  */
 package org.supercsv.io;
 
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.List;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.supercsv.exception.SuperCsvException;
 import org.supercsv.prefs.CsvPreference;
-
-import java.io.IOException;
-import java.io.Reader;
-import java.io.StringReader;
-import java.util.ArrayList;
-import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -256,7 +255,7 @@ public class TokenizerEscapingTest {
 	public void testDoubleQuoteBackslashEscapeChar() throws Exception {
 
 		// quote char is ' and escape char is $
-		final CsvPreference csvPref = new CsvPreference.Builder('\'', ',', "\n")
+		final CsvPreference csvPref = new CsvPreference.Builder('\'', ",", "\n")
 				.setQuoteEscapeChar('$')
 				.build();
 

--- a/super-csv/src/test/java/org/supercsv/io/TokenizerTest.java
+++ b/super-csv/src/test/java/org/supercsv/io/TokenizerTest.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2007 Kasper B. Graversen
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,19 +15,11 @@
  */
 package org.supercsv.io;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.supercsv.prefs.CsvPreference.EXCEL_PREFERENCE;
-
 import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.List;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -36,8 +28,11 @@ import org.supercsv.comment.CommentStartsWith;
 import org.supercsv.exception.SuperCsvException;
 import org.supercsv.prefs.CsvPreference;
 
+import static org.junit.Assert.*;
+import static org.supercsv.prefs.CsvPreference.EXCEL_PREFERENCE;
+
 public class TokenizerTest {
-	
+
 	private static final CsvPreference NORMAL_PREFERENCE = EXCEL_PREFERENCE;
 	private static final CsvPreference SPACES_NEED_QUOTES_PREFERENCE = new CsvPreference.Builder(EXCEL_PREFERENCE)
 		.surroundingSpacesNeedQuotes(true).build();
@@ -45,20 +40,20 @@ public class TokenizerTest {
 		.ignoreEmptyLines(false).build();
 	private static final CsvPreference PARSE_EMPTY_COLUMNS_AS_EMPTY_STRING_PREFERENCE = new CsvPreference.Builder(EXCEL_PREFERENCE)
 		.setEmptyColumnParsing(EmptyColumnParsing.ParseEmptyColumnsAsEmptyString).build();
-		
+
 	private Tokenizer tokenizer;
 	private List<String> columns;
-	
+
 	/**
 	 * Sets up the columns List for the test.
-	 * 
+	 *
 	 * @throws Exception
 	 */
 	@Before
 	public void setUp() {
 		columns = new ArrayList<String>();
 	}
-	
+
 	/**
 	 * Tidies up after the test.
 	 */
@@ -68,10 +63,10 @@ public class TokenizerTest {
 			tokenizer.close();
 		}
 	}
-	
+
 	/**
 	 * Creates a Tokenizer with the input and preferences.
-	 * 
+	 *
 	 * @param input
 	 *            the input String
 	 * @param preference
@@ -82,7 +77,7 @@ public class TokenizerTest {
 		final Reader r = input != null ? new StringReader(input) : null;
 		return new Tokenizer(r, preference);
 	}
-	
+
 	/**
 	 * Tests the constructor with a null Reader (should throw an Exception).
 	 */
@@ -90,7 +85,7 @@ public class TokenizerTest {
 	public void testConstructorWithNullReader() throws Exception {
 		createTokenizer(null, NORMAL_PREFERENCE);
 	}
-	
+
 	/**
 	 * Tests the constructor with a null CsvPreference (should throw an Exception).
 	 */
@@ -98,7 +93,7 @@ public class TokenizerTest {
 	public void testConstructorWithNullPreferences() throws Exception {
 		createTokenizer("", null);
 	}
-	
+
 	/**
 	 * Tests the readColumns() method with null List (should throw an Exception).
 	 */
@@ -107,7 +102,7 @@ public class TokenizerTest {
 		tokenizer = createTokenizer("", NORMAL_PREFERENCE);
 		tokenizer.readColumns(null);
 	}
-	
+
 	/**
 	 * Tests the getPreferences() method.
 	 */
@@ -115,12 +110,12 @@ public class TokenizerTest {
 	public void testGetPreferences() throws Exception {
 		tokenizer = createTokenizer("", NORMAL_PREFERENCE);
 		CsvPreference prefs = tokenizer.getPreferences();
-		assertEquals(NORMAL_PREFERENCE.getDelimiterChar(), prefs.getDelimiterChar());
+		assertEquals(NORMAL_PREFERENCE.getDelimiterSymbols(), prefs.getDelimiterSymbols());
 		assertEquals(NORMAL_PREFERENCE.getEndOfLineSymbols(), prefs.getEndOfLineSymbols());
 		assertEquals(NORMAL_PREFERENCE.getQuoteChar(), prefs.getQuoteChar());
 		assertEquals(NORMAL_PREFERENCE.isSurroundingSpacesNeedQuotes(), prefs.isSurroundingSpacesNeedQuotes());
 	}
-	
+
 	/**
 	 * Tests the readColumns() method with no data.
 	 */
@@ -132,13 +127,13 @@ public class TokenizerTest {
 		assertTrue(columns.isEmpty());
 		assertEquals(input, tokenizer.getUntokenizedRow());
 	}
-	
+
 	/**
 	 * Tests that the readColumns() method skips over empty lines.
 	 */
 	@Test
 	public void testEmptyLines() throws Exception {
-		
+
 		final String input = "\n\nthis is the third line\n";
 		tokenizer = createTokenizer(input, NORMAL_PREFERENCE);
 		tokenizer.readColumns(columns);
@@ -147,14 +142,14 @@ public class TokenizerTest {
 		assertEquals(3, tokenizer.getLineNumber());
 		assertEquals("this is the third line", tokenizer.getUntokenizedRow());
 	}
-	
+
 	/**
 	 * Tests that the readColumns() method doesn't skip over empty lines if the ignoreEmptyLines
 	 * preference is disabled.
 	 */
 	@Test
 	public void testEmptyLinesWithIgnoreEmptyLines() throws Exception {
-		
+
 		final String input = "\nthis is the second line\n\n";
 		tokenizer = createTokenizer(input, DONT_IGNORE_EMPTY_LINES_PREFERENCE);
 		tokenizer.readColumns(columns);
@@ -162,27 +157,27 @@ public class TokenizerTest {
 		assertNull(columns.get(0));
 		assertEquals(1, tokenizer.getLineNumber());
 		assertEquals("", tokenizer.getUntokenizedRow());
-		
+
 		tokenizer.readColumns(columns);
 		assertTrue(columns.size() == 1);
 		assertEquals("this is the second line", columns.get(0));
 		assertEquals(2, tokenizer.getLineNumber());
 		assertEquals("this is the second line", tokenizer.getUntokenizedRow());
-		
+
 		tokenizer.readColumns(columns);
 		assertTrue(columns.size() == 1);
 		assertNull(columns.get(0));
 		assertEquals(3, tokenizer.getLineNumber());
 		assertEquals("", tokenizer.getUntokenizedRow());
 	}
-	
+
 	/**
 	 * Tests the readColumns() method a quoted section has text surrounding it. This is not technically valid CSV, but
 	 * the tokenizer is lenient enough to allow it (it will just unescape the quoted section).
 	 */
 	@Test
 	public void testQuotedFieldWithSurroundingText() throws Exception {
-		
+
 		final String input = "surrounding \"quoted\" text";
 		tokenizer = createTokenizer(input, NORMAL_PREFERENCE);
 		tokenizer.readColumns(columns);
@@ -190,7 +185,7 @@ public class TokenizerTest {
 		assertEquals("surrounding quoted text", columns.get(0));
 		assertEquals(1, tokenizer.getLineNumber());
 		assertEquals(input, tokenizer.getUntokenizedRow());
-		
+
 		// same result when surrounding spaces require quotes
 		tokenizer = createTokenizer(input, SPACES_NEED_QUOTES_PREFERENCE);
 		tokenizer.readColumns(columns);
@@ -199,14 +194,14 @@ public class TokenizerTest {
 		assertEquals(1, tokenizer.getLineNumber());
 		assertEquals(input, tokenizer.getUntokenizedRow());
 	}
-	
+
 	/**
 	 * Tests the readColumns() method when a quoted section with text after it. This is not technically valid CSV, but
 	 * the tokenizer is lenient enough to allow it (it will just unescape the quoted section).
 	 */
 	@Test
 	public void testQuotedFieldWithTextAfter() throws Exception {
-		
+
 		// illegal char after quoted section
 		final String input = "\"quoted on 2 lines\nand afterward some\" text";
 		tokenizer = createTokenizer(input, NORMAL_PREFERENCE);
@@ -215,7 +210,7 @@ public class TokenizerTest {
 		assertEquals("quoted on 2 lines\nand afterward some text", columns.get(0));
 		assertEquals(2, tokenizer.getLineNumber());
 		assertEquals(input, tokenizer.getUntokenizedRow());
-		
+
 		// should have exactly the same result when surrounding spaces need quotes
 		tokenizer = createTokenizer(input, SPACES_NEED_QUOTES_PREFERENCE);
 		tokenizer.readColumns(columns);
@@ -224,20 +219,20 @@ public class TokenizerTest {
 		assertEquals(2, tokenizer.getLineNumber());
 		assertEquals(input, tokenizer.getUntokenizedRow());
 	}
-	
+
 	/**
 	 * Tests the readColumns() method with a single quoted newline.
 	 */
 	@Test
 	public void testQuotedNewline() throws Exception {
-		
+
 		final String input = "\"\n\"";
 		tokenizer = createTokenizer(input, NORMAL_PREFERENCE);
 		tokenizer.readColumns(columns);
 		assertTrue(columns.size() == 1);
 		assertEquals("\n", columns.get(0));
 		assertEquals(input, tokenizer.getUntokenizedRow());
-		
+
 		// same input when surrounding spaces require quotes (results should be identical)
 		tokenizer = createTokenizer(input, SPACES_NEED_QUOTES_PREFERENCE);
 		tokenizer.readColumns(columns);
@@ -245,13 +240,13 @@ public class TokenizerTest {
 		assertEquals("\n", columns.get(0));
 		assertEquals(input, tokenizer.getUntokenizedRow());
 	}
-	
+
 	/**
 	 * Tests the readColumns() method with a variety of quoted newlines.
 	 */
 	@Test
 	public void testQuotedNewlines() throws Exception {
-		
+
 		final String input = "\"one line\",\"two\nlines\",\"three\nlines\n!\"";
 		tokenizer = createTokenizer(input, NORMAL_PREFERENCE);
 		tokenizer.readColumns(columns);
@@ -260,7 +255,7 @@ public class TokenizerTest {
 		assertEquals("two\nlines", columns.get(1));
 		assertEquals("three\nlines\n!", columns.get(2));
 		assertEquals(input, tokenizer.getUntokenizedRow());
-		
+
 		// same input when surrounding spaces require quotes (results should be identical)
 		tokenizer = createTokenizer(input, SPACES_NEED_QUOTES_PREFERENCE);
 		tokenizer.readColumns(columns);
@@ -270,14 +265,14 @@ public class TokenizerTest {
 		assertEquals("three\nlines\n!", columns.get(2));
 		assertEquals(input, tokenizer.getUntokenizedRow());
 	}
-	
-	
+
+
 	/**
 	 * Tests the readColumns() method when a quoted field has consecutive newlines.
 	 */
 	@Test
 	public void testQuotedTextWithConsecutiveNewLines() throws Exception {
-		
+
 		// second field has consecutive newlines
 		final String input = "one, \"multiline\n\n\ntext\"";
 		tokenizer = createTokenizer(input, NORMAL_PREFERENCE);
@@ -287,7 +282,7 @@ public class TokenizerTest {
 		assertEquals(" multiline\n\n\ntext", columns.get(1));
 		assertEquals(4, tokenizer.getLineNumber());
 		assertEquals(input, tokenizer.getUntokenizedRow());
-		
+
 		// should have exactly the same result when surrounding spaces need quotes
 		tokenizer = createTokenizer(input, SPACES_NEED_QUOTES_PREFERENCE);
 		tokenizer.readColumns(columns);
@@ -296,13 +291,13 @@ public class TokenizerTest {
 		assertEquals("multiline\n\n\ntext", columns.get(1));
 		assertEquals(input, tokenizer.getUntokenizedRow());
 	}
-	
+
 	/**
 	 * Tests the readColumns() method when EOF is reached within quote scope.
 	 */
 	@Test
 	public void testQuotedFieldWithUnexpectedEOF() throws Exception {
-		
+
 		// EOF reached within quote scope
 		final String input = "\"quoted spanning\ntwo lines with EOF reached before another quote";
 		tokenizer = createTokenizer(input, NORMAL_PREFERENCE);
@@ -409,7 +404,7 @@ public class TokenizerTest {
 		assertEquals(true , fourth);
 		assertEquals("[aaa, bbb]" , columns.toString());
 
-		//line 4 was the last 
+		//line 4 was the last
 		final boolean fifth = tokenizer.readColumns(columns);
 		assertEquals(false , fifth);
 	}
@@ -434,7 +429,7 @@ public class TokenizerTest {
 			boolean first = tokenizer.readColumns(columns);
 			assertEquals(true , first);
 			assertEquals("[col1, col2]" , columns.toString());
-			
+
 
 			boolean second = tokenizer.readColumns(columns);
 			assertEquals(true , second);
@@ -451,7 +446,7 @@ public class TokenizerTest {
 		boolean fourth = tokenizer.readColumns(columns);
 		assertEquals(true , fourth);
 		assertEquals("[aaa, bbb]" , columns.toString());
-		
+
 	}
 
 	/**
@@ -461,7 +456,7 @@ public class TokenizerTest {
 	 */
 	@Test
 	public void testQuotedFirstFieldWithLeadingSpace() throws Exception {
-		
+
 		// leading spaces should be preserved
 		final String input = "  \"quoted with leading spaces\",two";
 		tokenizer = createTokenizer(input, NORMAL_PREFERENCE);
@@ -470,7 +465,7 @@ public class TokenizerTest {
 		assertEquals("  quoted with leading spaces", columns.get(0));
 		assertEquals("two", columns.get(1));
 		assertEquals(input, tokenizer.getUntokenizedRow());
-		
+
 		// same input when surrounding spaces require quotes (leading spaces trimmed)
 		tokenizer = createTokenizer(input, SPACES_NEED_QUOTES_PREFERENCE);
 		tokenizer.readColumns(columns);
@@ -479,7 +474,7 @@ public class TokenizerTest {
 		assertEquals("two", columns.get(1));
 		assertEquals(input, tokenizer.getUntokenizedRow());
 	}
-	
+
 	/**
 	 * Tests the readColumns() method with a leading space before the last quoted field. This is not technically valid
 	 * CSV, but the tokenizer is lenient enough to allow it. The leading spaces will be trimmed off when surrounding
@@ -487,7 +482,7 @@ public class TokenizerTest {
 	 */
 	@Test
 	public void testQuotedLastFieldWithLeadingSpace() throws Exception {
-		
+
 		// last field has a leading space before quote (should be preserved)
 		final String input = "one,two,  \"quoted with leading spaces\"";
 		tokenizer = createTokenizer(input, NORMAL_PREFERENCE);
@@ -497,7 +492,7 @@ public class TokenizerTest {
 		assertEquals("two", columns.get(1));
 		assertEquals("  quoted with leading spaces", columns.get(2));
 		assertEquals(input, tokenizer.getUntokenizedRow());
-		
+
 		// leading space should be trimmed off
 		tokenizer = createTokenizer(input, SPACES_NEED_QUOTES_PREFERENCE);
 		tokenizer.readColumns(columns);
@@ -507,7 +502,7 @@ public class TokenizerTest {
 		assertEquals("quoted with leading spaces", columns.get(2));
 		assertEquals(input, tokenizer.getUntokenizedRow());
 	}
-	
+
 	/**
 	 * Tests the readColumns() method with a trailing space after the first quoted field. This is not technically valid
 	 * CSV, but the tokenizer is lenient enough to allow it. The trailing spaces will be trimmed off when surrounding
@@ -515,7 +510,7 @@ public class TokenizerTest {
 	 */
 	@Test
 	public void testQuotedFirstFieldWithTrailingSpace() throws Exception {
-		
+
 		// first field has a leading space before quote (should be preserved)
 		final String input = "\"quoted with trailing spaces\"  ,two";
 		tokenizer = createTokenizer(input, NORMAL_PREFERENCE);
@@ -524,7 +519,7 @@ public class TokenizerTest {
 		assertEquals("quoted with trailing spaces  ", columns.get(0));
 		assertEquals("two", columns.get(1));
 		assertEquals(input, tokenizer.getUntokenizedRow());
-		
+
 		// trailing spaces should be trimmed
 		tokenizer = createTokenizer(input, SPACES_NEED_QUOTES_PREFERENCE);
 		tokenizer.readColumns(columns);
@@ -533,7 +528,7 @@ public class TokenizerTest {
 		assertEquals("two", columns.get(1));
 		assertEquals(input, tokenizer.getUntokenizedRow());
 	}
-	
+
 	/**
 	 * Tests the readColumns() method with a trailing space after the last quoted field. This is not technically valid
 	 * CSV, but the tokenizer is lenient enough to allow it. The trailing spaces will be trimmed off when surrounding
@@ -541,7 +536,7 @@ public class TokenizerTest {
 	 */
 	@Test
 	public void testQuotedLastFieldWithTrailingSpace() throws Exception {
-		
+
 		// last field has a leading space before quote (should be preserved)
 		final String input = "one,two,\"quoted with trailing spaces\"  ";
 		tokenizer = createTokenizer(input, NORMAL_PREFERENCE);
@@ -551,7 +546,7 @@ public class TokenizerTest {
 		assertEquals("two", columns.get(1));
 		assertEquals("quoted with trailing spaces  ", columns.get(2));
 		assertEquals(input, tokenizer.getUntokenizedRow());
-		
+
 		// trailing spaces should be trimmed off
 		tokenizer = createTokenizer(input, SPACES_NEED_QUOTES_PREFERENCE);
 		tokenizer.readColumns(columns);
@@ -561,13 +556,13 @@ public class TokenizerTest {
 		assertEquals("quoted with trailing spaces", columns.get(2));
 		assertEquals(input, tokenizer.getUntokenizedRow());
 	}
-	
+
 	/**
 	 * Tests the readColumns() method with a variety of quoted spaces.
 	 */
 	@Test
 	public void testQuotedSpaces() throws Exception {
-		
+
 		final String input = "\" one \",\"  two  \",\"   three   \"";
 		tokenizer = createTokenizer(input, NORMAL_PREFERENCE);
 		tokenizer.readColumns(columns);
@@ -576,7 +571,7 @@ public class TokenizerTest {
 		assertEquals("  two  ", columns.get(1));
 		assertEquals("   three   ", columns.get(2));
 		assertEquals(input, tokenizer.getUntokenizedRow());
-		
+
 		// same input when surrounding spaces require quotes (results should be identical)
 		tokenizer = createTokenizer(input, SPACES_NEED_QUOTES_PREFERENCE);
 		tokenizer.readColumns(columns);
@@ -586,13 +581,13 @@ public class TokenizerTest {
 		assertEquals("   three   ", columns.get(2));
 		assertEquals(input, tokenizer.getUntokenizedRow());
 	}
-	
+
 	/**
 	 * Tests the readColumns() method with a variety of unquoted spaces.
 	 */
 	@Test
 	public void testSpaces() throws Exception {
-		
+
 		final String input = " one ,  two  ,   three   ";
 		tokenizer = createTokenizer(input, NORMAL_PREFERENCE);
 		tokenizer.readColumns(columns);
@@ -601,7 +596,7 @@ public class TokenizerTest {
 		assertEquals("  two  ", columns.get(1));
 		assertEquals("   three   ", columns.get(2));
 		assertEquals(input, tokenizer.getUntokenizedRow());
-		
+
 		// same input when surrounding spaces require quotes
 		tokenizer = createTokenizer(input, SPACES_NEED_QUOTES_PREFERENCE);
 		tokenizer.readColumns(columns);
@@ -611,13 +606,13 @@ public class TokenizerTest {
 		assertEquals("three", columns.get(2));
 		assertEquals(input, tokenizer.getUntokenizedRow());
 	}
-	
+
 	/**
 	 * Tests the readColumns() method with a variety of spaces and tabs.
 	 */
 	@Test
 	public void testSpacesAndTabs() throws Exception {
-		
+
 		// tabs should never be trimmed
 		final String input = "\t, \tone\t ,  \ttwo\t  ,   \tthree\t   ";
 		tokenizer = createTokenizer(input, NORMAL_PREFERENCE);
@@ -628,7 +623,7 @@ public class TokenizerTest {
 		assertEquals("  \ttwo\t  ", columns.get(2));
 		assertEquals("   \tthree\t   ", columns.get(3));
 		assertEquals(input, tokenizer.getUntokenizedRow());
-		
+
 		// same input when surrounding spaces require quotes
 		tokenizer = createTokenizer(input, SPACES_NEED_QUOTES_PREFERENCE);
 		tokenizer.readColumns(columns);
@@ -639,13 +634,13 @@ public class TokenizerTest {
 		assertEquals("\tthree\t", columns.get(3));
 		assertEquals(input, tokenizer.getUntokenizedRow());
 	}
-	
+
 	/**
 	 * Tests the readColumns() method with spaces between words.
 	 */
 	@Test
 	public void testSpacesBetweenWords() throws Exception {
-		
+
 		final String input = " one partridge ,  two turtle doves  ,   three french hens   ";
 		tokenizer = createTokenizer(input, NORMAL_PREFERENCE);
 		tokenizer.readColumns(columns);
@@ -654,7 +649,7 @@ public class TokenizerTest {
 		assertEquals("  two turtle doves  ", columns.get(1));
 		assertEquals("   three french hens   ", columns.get(2));
 		assertEquals(input, tokenizer.getUntokenizedRow());
-		
+
 		// same input when surrounding spaces require quotes
 		tokenizer = createTokenizer(input, SPACES_NEED_QUOTES_PREFERENCE);
 		tokenizer.readColumns(columns);
@@ -664,16 +659,16 @@ public class TokenizerTest {
 		assertEquals("three french hens", columns.get(2));
 		assertEquals(input, tokenizer.getUntokenizedRow());
 	}
-	
+
 	/**
 	 * Tests that the CommentStartsWith comment matcher works (comments are skipped).
 	 */
 	@Test
 	public void testSkipCommentsStartsWith() throws IOException {
-		
+
 		final CsvPreference commentsStartWithPrefs = new CsvPreference.Builder(EXCEL_PREFERENCE).skipComments(
 			new CommentStartsWith("#")).build();
-		
+
 		final String input = "#comment\nnot,a,comment\n# another comment\nalso,not,comment";
 		final Tokenizer tokenizer = createTokenizer(input, commentsStartWithPrefs);
 		tokenizer.readColumns(columns);
@@ -681,25 +676,25 @@ public class TokenizerTest {
 		assertEquals("not", columns.get(0));
 		assertEquals("a", columns.get(1));
 		assertEquals("comment", columns.get(2));
-		
+
 		tokenizer.readColumns(columns);
 		assertTrue(columns.size() == 3);
 		assertEquals("also", columns.get(0));
 		assertEquals("not", columns.get(1));
 		assertEquals("comment", columns.get(2));
-		
+
 		assertFalse(tokenizer.readColumns(columns));
 	}
-	
+
 	/**
 	 * Tests that the CommentMatches comment matcher works (comments are skipped).
 	 */
 	@Test
 	public void testSkipCommentsMatches() throws IOException {
-		
+
 		final CsvPreference commentsMatchesPrefs = new CsvPreference.Builder(EXCEL_PREFERENCE).skipComments(
 			new CommentMatches("<!--.*-->")).build();
-		
+
 		final String input = "<!--comment-->\nnot,a,comment\n<!-- another comment-->\nalso,not,comment";
 		final Tokenizer tokenizer = createTokenizer(input, commentsMatchesPrefs);
 		tokenizer.readColumns(columns);
@@ -707,84 +702,84 @@ public class TokenizerTest {
 		assertEquals("not", columns.get(0));
 		assertEquals("a", columns.get(1));
 		assertEquals("comment", columns.get(2));
-		
+
 		tokenizer.readColumns(columns);
 		assertTrue(columns.size() == 3);
 		assertEquals("also", columns.get(0));
 		assertEquals("not", columns.get(1));
 		assertEquals("comment", columns.get(2));
-		
+
 		assertFalse(tokenizer.readColumns(columns));
-		
+
 	}
-	
+
 	/**
 	 * Tests that the readColumns() method reads a null column as null when preferences is ParseEmptyColumnsAsNull.
 	 */
 	@Test
 	public void testReadNullWithParseEmptyColumnsAsNull() throws Exception {
-		
+
 		final String input = ",";
 		tokenizer = createTokenizer(input, NORMAL_PREFERENCE);
 		assertTrue(NORMAL_PREFERENCE.getEmptyColumnParsing().equals(EmptyColumnParsing.ParseEmptyColumnsAsNull));
-		
+
 		tokenizer.readColumns(columns);
 		assertTrue(columns.size() == 2);
 		assertEquals(",", tokenizer.getUntokenizedRow());
 		assertEquals(null, columns.get(0));
 		assertEquals(null, columns.get(1));
 	}
-	
+
 
 	/**
 	 * Tests that the readColumns() method reads an empty string column as null when preferences is ParseEmptyColumnsAsNull.
 	 */
 	@Test
 	public void testReadEmptyStringsWithParseEmptyColumnsAsNull() throws Exception {
-		
+
 		final String input = "\"\",\"\"";
 		tokenizer = createTokenizer(input, NORMAL_PREFERENCE);
 		assertTrue(NORMAL_PREFERENCE.getEmptyColumnParsing().equals(EmptyColumnParsing.ParseEmptyColumnsAsNull));
-		
+
 		tokenizer.readColumns(columns);
 		assertTrue(columns.size() == 2);
 		assertEquals("\"\",\"\"", tokenizer.getUntokenizedRow());
 		assertEquals(null, columns.get(0));
 		assertEquals(null, columns.get(1));
 	}
-	
+
 	/**
 	 * Tests that the readColumns() method reads a null column as null when preferences is ParseEmptyColumnsAsEmptyString.
 	 */
 	@Test
 	public void testReadNullWithParseEmptyColumnsAsEmptyString() throws Exception {
-		
+
 		final String input = ",";
 		tokenizer = createTokenizer(input, PARSE_EMPTY_COLUMNS_AS_EMPTY_STRING_PREFERENCE);
 		assertTrue(PARSE_EMPTY_COLUMNS_AS_EMPTY_STRING_PREFERENCE.getEmptyColumnParsing().equals(EmptyColumnParsing.ParseEmptyColumnsAsEmptyString));
-		
+
 		tokenizer.readColumns(columns);
 		assertTrue(columns.size() == 2);
 		assertEquals(",", tokenizer.getUntokenizedRow());
 		assertEquals(null, columns.get(0));
 		assertEquals(null, columns.get(1));
 	}
-	
+
 	/**
 	 * Tests that the readColumns() method reads an empty string column as empty string when preferences is ParseEmptyColumnsAsEmptyString.
 	 */
 	@Test
 	public void testReadEmptyStringsWithParseEmptyColumnsAsEmptyString() throws Exception {
-		
+
 		final String input = "\"\",\"\"";
 		tokenizer = createTokenizer(input, PARSE_EMPTY_COLUMNS_AS_EMPTY_STRING_PREFERENCE);
 		assertTrue(PARSE_EMPTY_COLUMNS_AS_EMPTY_STRING_PREFERENCE.getEmptyColumnParsing().equals(EmptyColumnParsing.ParseEmptyColumnsAsEmptyString));
-		
+
 		tokenizer.readColumns(columns);
 		assertTrue(columns.size() == 2);
 		assertEquals("\"\",\"\"", tokenizer.getUntokenizedRow());
 		assertEquals("", columns.get(0));
 		assertEquals("", columns.get(1));
-	}	
-	
+	}
+
 }

--- a/super-csv/src/test/java/org/supercsv/prefs/CsvPreferenceTest.java
+++ b/super-csv/src/test/java/org/supercsv/prefs/CsvPreferenceTest.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2007 Kasper B. Graversen
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,58 +15,52 @@
  */
 package org.supercsv.prefs;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.supercsv.prefs.CsvPreference.EXCEL_NORTH_EUROPE_PREFERENCE;
-import static org.supercsv.prefs.CsvPreference.EXCEL_PREFERENCE;
-import static org.supercsv.prefs.CsvPreference.STANDARD_PREFERENCE;
-import static org.supercsv.prefs.CsvPreference.TAB_PREFERENCE;
-
 import org.junit.Assert;
 import org.junit.Test;
 import org.supercsv.encoder.DefaultCsvEncoder;
 import org.supercsv.quote.AlwaysQuoteMode;
 import org.supercsv.quote.NormalQuoteMode;
 
+import static org.junit.Assert.*;
+import static org.supercsv.prefs.CsvPreference.*;
+
 /**
  * Tests the CsvPreference class.
- * 
+ *
  * @author James Bassett
  */
 public class CsvPreferenceTest {
-	
+
 	/**
 	 * Tests the constant values.
 	 */
 	@Test
 	public void testConstants() {
 		assertEquals('"', STANDARD_PREFERENCE.getQuoteChar());
-		assertEquals(',', STANDARD_PREFERENCE.getDelimiterChar());
+		assertEquals(",", STANDARD_PREFERENCE.getDelimiterSymbols());
 		assertEquals("\r\n", STANDARD_PREFERENCE.getEndOfLineSymbols());
-		
+
 		assertEquals('"', EXCEL_PREFERENCE.getQuoteChar());
-		assertEquals(',', EXCEL_PREFERENCE.getDelimiterChar());
+		assertEquals(",", EXCEL_PREFERENCE.getDelimiterSymbols());
 		assertEquals("\n", EXCEL_PREFERENCE.getEndOfLineSymbols());
-		
+
 		assertEquals('"', EXCEL_NORTH_EUROPE_PREFERENCE.getQuoteChar());
-		assertEquals(';', EXCEL_NORTH_EUROPE_PREFERENCE.getDelimiterChar());
+		assertEquals(";", EXCEL_NORTH_EUROPE_PREFERENCE.getDelimiterSymbols());
 		assertEquals("\n", EXCEL_NORTH_EUROPE_PREFERENCE.getEndOfLineSymbols());
-		
+
 		assertEquals('"', TAB_PREFERENCE.getQuoteChar());
-		assertEquals('\t', TAB_PREFERENCE.getDelimiterChar());
+		assertEquals("\t", TAB_PREFERENCE.getDelimiterSymbols());
 		assertEquals("\n", TAB_PREFERENCE.getEndOfLineSymbols());
 	}
-	
+
 	/**
 	 * Tests a custom CsvPreference with default optional values.
 	 */
 	@Test
 	public void testCustomPreferenceWithDefaults() {
-		final CsvPreference custom = new CsvPreference.Builder('"', ',', "\n").build();
+		final CsvPreference custom = new Builder('"', ",", "\n").build();
 		assertEquals('"', custom.getQuoteChar());
-		assertEquals(',', custom.getDelimiterChar());
+		assertEquals(",", custom.getDelimiterSymbols());
 		assertEquals("\n", custom.getEndOfLineSymbols());
 		assertFalse(custom.isSurroundingSpacesNeedQuotes());
 		assertNull(custom.getCommentMatcher());
@@ -74,69 +68,69 @@ public class CsvPreferenceTest {
 		assertTrue(custom.getQuoteMode() instanceof NormalQuoteMode);
 		assertEquals('"', custom.getQuoteEscapeChar());
 	}
-	
+
 	/**
 	 * Tests a custom CsvPreference with supplied optional values.
 	 */
 	@Test
 	public void testCustomPreference() {
-		final CsvPreference custom = new CsvPreference.Builder('"', ',', "\n")
+		final CsvPreference custom = new Builder('"', ",", "\n")
 				.surroundingSpacesNeedQuotes(true)
 				.useEncoder(new DefaultCsvEncoder())
 				.useQuoteMode(new AlwaysQuoteMode())
 				.setQuoteEscapeChar('\\')
 				.build();
 		assertEquals('"', custom.getQuoteChar());
-		assertEquals(',', custom.getDelimiterChar());
+		assertEquals(",", custom.getDelimiterSymbols());
 		assertEquals("\n", custom.getEndOfLineSymbols());
 		assertTrue(custom.isSurroundingSpacesNeedQuotes());
 		assertTrue(custom.getEncoder() instanceof DefaultCsvEncoder);
 		assertTrue(custom.getQuoteMode() instanceof AlwaysQuoteMode);
 		assertEquals('\\', custom.getQuoteEscapeChar());
 	}
-	
+
 	/**
 	 * Tests a custom CsvPreference based on an existing constant with default optional values.
 	 */
 	@Test
 	public void testCustomPreferenceBasedOnExistingWithDefaults() {
-		final CsvPreference custom = new CsvPreference.Builder(EXCEL_PREFERENCE).build();
+		final CsvPreference custom = new Builder(EXCEL_PREFERENCE).build();
 		assertEquals(EXCEL_PREFERENCE.getQuoteChar(), custom.getQuoteChar());
-		assertEquals(EXCEL_PREFERENCE.getDelimiterChar(), custom.getDelimiterChar());
+		assertEquals(EXCEL_PREFERENCE.getDelimiterSymbols(), custom.getDelimiterSymbols());
 		assertEquals(EXCEL_PREFERENCE.getEndOfLineSymbols(), custom.getEndOfLineSymbols());
 		assertEquals(EXCEL_PREFERENCE.isSurroundingSpacesNeedQuotes(), custom.isSurroundingSpacesNeedQuotes());
 		assertEquals(EXCEL_PREFERENCE.getEncoder(), custom.getEncoder());
 		assertEquals(EXCEL_PREFERENCE.getQuoteMode(), custom.getQuoteMode());
 		assertEquals(EXCEL_PREFERENCE.getQuoteEscapeChar(), custom.getQuoteEscapeChar());
 	}
-	
+
 	/**
 	 * Tests a custom CsvPreference based on an existing constant with supplied optional values.
 	 */
 	@Test
 	public void testCustomPreferenceBasedOnExisting() {
-		final CsvPreference custom = new CsvPreference.Builder(EXCEL_PREFERENCE).surroundingSpacesNeedQuotes(true)
+		final CsvPreference custom = new Builder(EXCEL_PREFERENCE).surroundingSpacesNeedQuotes(true)
 			.useEncoder(new DefaultCsvEncoder()).useQuoteMode(new AlwaysQuoteMode()).build();
 		assertEquals(EXCEL_PREFERENCE.getQuoteChar(), custom.getQuoteChar());
-		assertEquals(EXCEL_PREFERENCE.getDelimiterChar(), custom.getDelimiterChar());
+		assertEquals(EXCEL_PREFERENCE.getDelimiterSymbols(), custom.getDelimiterSymbols());
 		assertEquals(EXCEL_PREFERENCE.getEndOfLineSymbols(), custom.getEndOfLineSymbols());
 		assertTrue(custom.isSurroundingSpacesNeedQuotes());
 		assertTrue(custom.getEncoder() instanceof DefaultCsvEncoder);
 		assertTrue(custom.getQuoteMode() instanceof AlwaysQuoteMode);
 		assertEquals(EXCEL_PREFERENCE.getQuoteEscapeChar(), custom.getQuoteEscapeChar());
 	}
-	
+
 	/**
 	 * Tests a custom CsvPreference with identical quote and delimiter chars (should throw an exception).
 	 */
 	@Test(expected = IllegalArgumentException.class)
 	public void testCustomPreferenceWithInvalidQuoteAndDelimeterChars() {
-		new CsvPreference.Builder('|', '|', "\n").build();
+		new Builder('|', "|", "\n").build();
 	}
 
 	@Test
 	public void testCustomPreferenceWithSameDelimiterAndQuoteEscapeChar() {
-		CsvPreference.Builder builder = new CsvPreference.Builder('"', ',', "\n").setQuoteEscapeChar(',');
+		Builder builder = new Builder('"', ",", "\n").setQuoteEscapeChar(',');
 
 		try {
 			builder.build();
@@ -145,36 +139,36 @@ public class CsvPreferenceTest {
 			assertTrue(e.getMessage().contains("must not be the same character"));
 		}
 	}
-	
+
 	/**
 	 * Tests construction with null end of line symbols (should throw an exception).
 	 */
 	@Test(expected = NullPointerException.class)
 	public void testConstructorWithNullEolSymbols() {
-		new CsvPreference.Builder('"', ',', null).build();
+		new Builder('"', ",", null).build();
 	}
-	
+
 	/**
 	 * Tests construction with null end of line symbols (should throw an exception).
 	 */
 	@Test(expected = NullPointerException.class)
 	public void testSkipCommentsWithNullCommentMatcher() {
-		new CsvPreference.Builder(EXCEL_PREFERENCE).skipComments(null).build();
+		new Builder(EXCEL_PREFERENCE).skipComments(null).build();
 	}
-	
+
 	/**
 	 * Tests construction with null encoder (should throw an exception).
 	 */
 	@Test(expected = NullPointerException.class)
 	public void testUseEncoderWithNull() {
-		new CsvPreference.Builder(EXCEL_PREFERENCE).useEncoder(null).build();
+		new Builder(EXCEL_PREFERENCE).useEncoder(null).build();
 	}
-	
+
 	/**
 	 * Tests construction with null quote mode (should throw an exception).
 	 */
 	@Test(expected = NullPointerException.class)
 	public void testUseQuoteModeWithNull() {
-		new CsvPreference.Builder(EXCEL_PREFERENCE).useQuoteMode(null).build();
+		new Builder(EXCEL_PREFERENCE).useQuoteMode(null).build();
 	}
 }


### PR DESCRIPTION
Hello,

I made some changes with regards to issue #10 , as I have encountered the same issue quite a few times.

The main changes lie in Tokenizer and CsvPreferences.
(a lot of files were modified because of my IDE replacing spaces, sorry for that)

Please note that I had a focus on **reading** purposes when making theses modifications.
An exception is thrown in DefaultCsvEncoder.encode if the delimiter has more than one character, _preventing the use of such a delimiter when writing_.

Thanks for the review,
Regards.