### PR TITLE
#77 Quote within quote should fail validation if it's not escaped

### DIFF
--- a/super-csv/src/main/java/org/supercsv/io/AllowNonEscapedQuotesTokenizer.java
+++ b/super-csv/src/main/java/org/supercsv/io/AllowNonEscapedQuotesTokenizer.java
@@ -155,10 +155,10 @@ public class AllowNonEscapedQuotesTokenizer extends AbstractTokenizer {
 					
 					currentRow.append(line); // update untokenized CSV row
 					
-				    if (line.length() == 0){
-				    	// consecutive newlines
-                        continue;
-				    }
+					if (line.length() == 0){
+						// consecutive newlines
+						continue;
+					}
 				}
 			}
 			
@@ -222,7 +222,7 @@ public class AllowNonEscapedQuotesTokenizer extends AbstractTokenizer {
 				
 				if( c == quoteChar ) {
 					/*
-					 * (?) Thinking the edge case
+					 * Case when c is last char in line
 					 * "Hello World","Java"
 					 *                    ^
 					 *                 charIndex = 19

--- a/super-csv/src/main/java/org/supercsv/io/AllowNonEscapedQuotesTokenizer.java
+++ b/super-csv/src/main/java/org/supercsv/io/AllowNonEscapedQuotesTokenizer.java
@@ -1,0 +1,297 @@
+package org.supercsv.io;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.util.List;
+
+import org.supercsv.comment.CommentMatcher;
+import org.supercsv.exception.SuperCsvException;
+import org.supercsv.io.AbstractTokenizer;
+import org.supercsv.prefs.CsvPreference;
+
+/**
+ * As per RFC standard every quote in value must be escaped by another quote. i.e,<code> Hello "World" -> Hello ""World"" </code>
+ * If file does not comply RFC, this tokenizer does work around by assuming " as a part of a value if character next to it is not comma.
+ * 
+ * <p>
+ * Example :
+ * 	NonEscaped Quotes ->
+ * 		"123466","Hello "World","ABC"  will be parsed as [123466, Hello "World, ABC]
+ * 		"123466",""Hello" World","ABC" -> [123466, "Hello" World, ABC]
+ * 
+ * Escaped Quotes ->
+ * 		"123466","Hello "Wor""ld","ABC" -> [123466, Hello Wor"ld, ABC]
+ * 		"123466","Hello "World""","ABC" -> [123466, Hello "World", ABC]
+ * </p>
+ * This tokenizer expects AlwaysQuoteMode enabled
+ * @author Nilesh.Akhade
+ *
+ */
+public class AllowNonEscapedQuotesTokenizer extends AbstractTokenizer {
+
+	private static final char NEWLINE = '\n';
+	
+	private static final char SPACE = ' ';
+	
+	private final StringBuilder currentColumn = new StringBuilder();
+	
+	/* the raw, untokenized CSV row (may span multiple lines) */
+	private final StringBuilder currentRow = new StringBuilder();
+	
+	private final int quoteChar;
+	
+	private final int delimeterChar;
+	
+	private final boolean surroundingSpacesNeedQuotes;
+	
+	private final boolean ignoreEmptyLines;
+	
+	private final CommentMatcher commentMatcher;
+
+	private final int maxLinesPerRow;
+
+	//private QuoteMode quoteMode;
+	
+	/**
+	 * Enumeration of tokenizer states. QUOTE_MODE is activated between quotes.
+	 */
+	private enum TokenizerState {
+		NORMAL, QUOTE_MODE;
+	}
+	
+	public AllowNonEscapedQuotesTokenizer(Reader reader, CsvPreference preferences) {
+		super(reader, preferences);
+		this.quoteChar = preferences.getQuoteChar();
+		this.delimeterChar = preferences.getDelimiterChar();
+		this.surroundingSpacesNeedQuotes = preferences.isSurroundingSpacesNeedQuotes();
+		this.ignoreEmptyLines = preferences.isIgnoreEmptyLines();
+		this.commentMatcher = preferences.getCommentMatcher();
+		this.maxLinesPerRow = preferences.getMaxLinesPerRow();
+//		this.quoteMode = preferences.getQuoteMode();
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 */
+	public boolean readColumns(final List<String> columns) throws IOException {
+		
+		if( columns == null ) {
+			throw new NullPointerException("columns should not be null");
+		}
+		
+		// clear the reusable List and StringBuilders
+		columns.clear();
+		currentColumn.setLength(0);
+		currentRow.setLength(0);
+		
+		// read a line (ignoring empty lines/comments if necessary)
+		String line;
+		do {
+			line = readLine();
+			if( line == null ) {
+				return false; // EOF
+			}
+		}
+		while( ignoreEmptyLines && line.length() == 0 || (commentMatcher != null && commentMatcher.isComment(line)) );
+		
+		// update the untokenized CSV row
+		currentRow.append(line);
+		
+		// process each character in the line, catering for surrounding quotes (QUOTE_MODE)
+		TokenizerState state = TokenizerState.NORMAL;
+		int quoteScopeStartingLine = -1; // the line number where a potential multi-line cell starts
+		int potentialSpaces = 0; // keep track of spaces (so leading/trailing space can be removed if required)
+		int charIndex = 0;
+		while( true ) {
+			boolean endOfLineReached = charIndex == line.length();
+			
+			if( endOfLineReached )
+			{
+				if( TokenizerState.NORMAL.equals(state) ) {
+					/*
+					 * Newline. Add any required spaces (if surrounding spaces don't need quotes) and return (we've read
+					 * a line!).
+					 */
+					if( !surroundingSpacesNeedQuotes ) {
+						appendSpaces(currentColumn, potentialSpaces);
+					}
+					columns.add(currentColumn.length() > 0 ? currentColumn.toString() : null); // "" -> null
+					return true;
+				}
+				else
+				{
+					/*
+					 * Newline. Doesn't count as newline while in QUOTESCOPE. Add the newline char, reset the charIndex
+					 * (will update to 0 for next iteration), read in the next line, then then continue to next
+					 * character.
+					 */
+					currentColumn.append(NEWLINE);
+					currentRow.append(NEWLINE); // specific line terminator lost, \n will have to suffice
+					
+					charIndex = 0;
+
+					if (maxLinesPerRow > 0 && getLineNumber() - quoteScopeStartingLine + 1 >= maxLinesPerRow) {
+						/*
+						 * The quoted section that is being parsed spans too many lines, so to avoid excessive memory
+						 * usage parsing something that is probably human error anyways, throw an exception. If each
+						 * row is suppose to be a single line and this has been exceeded, throw a more descriptive
+						 * exception
+						 */
+						String msg = maxLinesPerRow == 1 ?
+								String.format("unexpected end of line while reading quoted column on line %d",
+											  getLineNumber()) :
+								String.format("max number of lines to read exceeded while reading quoted column" +
+											  " beginning on line %d and ending on line %d",
+											  quoteScopeStartingLine, getLineNumber());
+						throw new SuperCsvException(msg);
+					}
+					else if( (line = readLine()) == null ) {
+						throw new SuperCsvException(
+							String
+								.format(
+									"unexpected end of file while reading quoted column beginning on line %d and ending on line %d",
+									quoteScopeStartingLine, getLineNumber()));
+					}
+					
+					currentRow.append(line); // update untokenized CSV row
+					
+				    if (line.length() == 0){
+				    	// consecutive newlines
+                        continue;
+				    }
+				}
+			}
+			
+			final char c = line.charAt(charIndex);
+			
+			if( TokenizerState.NORMAL.equals(state) ) {
+				
+				/*
+				 * NORMAL mode (not within quotes).
+				 */
+				
+				if( c == delimeterChar ) {
+					/*
+					 * Delimiter. Save the column (trim trailing space if required) then continue to next character.
+					 */
+					if( !surroundingSpacesNeedQuotes ) {
+						appendSpaces(currentColumn, potentialSpaces);
+					}
+					columns.add(currentColumn.length() > 0 ? currentColumn.toString() : null); // "" -> null
+					potentialSpaces = 0;
+					currentColumn.setLength(0);
+					
+				} else if( c == SPACE ) {
+					/*
+					 * Space. Remember it, then continue to next character.
+					 */
+					potentialSpaces++;
+					
+				}
+				else if( c == quoteChar ) {
+					/*
+					 * A single quote ("). Update to QUOTESCOPE (but don't save quote), then continue to next character.
+					 */
+					state = TokenizerState.QUOTE_MODE;
+					quoteScopeStartingLine = getLineNumber();
+					
+					// cater for spaces before a quoted section (be lenient!)
+					if( !surroundingSpacesNeedQuotes || currentColumn.length() > 0 ) {
+						appendSpaces(currentColumn, potentialSpaces);
+					}
+					potentialSpaces = 0;
+					
+				} else {
+					/*
+					 * Just a normal character. Add any required spaces (but trim any leading spaces if surrounding
+					 * spaces need quotes), add the character, then continue to next character.
+					 */
+					if( !surroundingSpacesNeedQuotes || currentColumn.length() > 0 ) {
+						appendSpaces(currentColumn, potentialSpaces);
+					}
+					
+					potentialSpaces = 0;
+					currentColumn.append(c);
+				}
+				
+			} else {
+				
+				/*
+				 * QUOTE_MODE (within quotes).
+				 */
+				
+				if( c == quoteChar ) {
+					/*
+					 * (?) Thinking the edge case
+					 * "Hello World","Java"
+					 *                    ^
+					 *                 charIndex = 19
+					 *             line.length() = 20
+					 *       availableCharacters = false
+					 */
+					int nextCharIndex = charIndex + 1;
+					boolean availableCharacters = nextCharIndex < line.length();
+					boolean nextCharIsNotDelimiter = availableCharacters && line.charAt(nextCharIndex) != delimeterChar;
+					if( nextCharIsNotDelimiter) {
+						/*
+						 * Hello",orld  (case when nextCharIsNotDelimiter is false because nextChar is ,)
+						 * Hello""orld  (case when nextCharIsNotDelimiter is true because nextChar is ")
+						 * Hello"World  (case when nextCharIsNotDelimiter is true because nextChar is W)
+						 *      ^
+						 *   charIndex
+						 * We want to allow non escaped quotes. Hence if next character is not comma then we will
+						 * consider quotes as a part of currentColumn.
+						 */
+						currentColumn.append(c);
+						
+						boolean nextCharIsQuote = line.charAt(nextCharIndex) == quoteChar;
+						if (nextCharIsQuote) {
+							/*
+							 * Hello""World  (case when nextCharIsQuote is true because nextChar is ")
+							 * We will assume this as escaped quotes so skip second quoteChar.
+							 */
+							charIndex++;
+						}
+						
+					} else {
+						/*
+						 * A single quote ("). Update to NORMAL (but don't save quote), then continue to next character.
+						 */
+						state = TokenizerState.NORMAL;
+						quoteScopeStartingLine = -1; // reset ready for next multi-line cell
+					}
+				} else {
+					/*
+					 * Just a normal character, delimiter (they don't count in QUOTESCOPE) or space. Add the character,
+					 * then continue to next character.
+					 */
+					currentColumn.append(c);
+				}
+			}
+			
+			charIndex++; // read next char of the line
+		}
+	}
+	
+	/**
+	 * Appends the required number of spaces to the StringBuilder.
+	 * 
+	 * @param sb
+	 *            the StringBuilder
+	 * @param spaces
+	 *            the required number of spaces to append
+	 */
+	private static void appendSpaces(final StringBuilder sb, final int spaces) {
+		for( int i = 0; i < spaces; i++ ) {
+			sb.append(SPACE);
+		}
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 */
+	public String getUntokenizedRow() {
+		return currentRow.toString();
+	}
+
+}

--- a/super-csv/src/main/java/org/supercsv/io/RejectNonEscapedQuotesTokenizer.java
+++ b/super-csv/src/main/java/org/supercsv/io/RejectNonEscapedQuotesTokenizer.java
@@ -1,0 +1,305 @@
+package org.supercsv.io;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.util.List;
+
+import org.supercsv.comment.CommentMatcher;
+import org.supercsv.exception.SuperCsvException;
+import org.supercsv.io.AbstractTokenizer;
+import org.supercsv.prefs.CsvPreference;
+
+/**
+ * As per RFC standard every quote in value must be escaped by another quote. i.e,<code> Hello "World" -> Hello ""World"" </code>
+ * If file does not comply RFC, this tokenizer rejects that record.
+ * 
+ * <p>
+ * Example :
+ * 	NonEscaped Quotes (Rejected) ->
+ * 		"123466","Hello "World","ABC"
+ * 		"123466",""Hello" World","ABC"
+ * 		"123466","Hello",World","ABC" This is rejected. Tool finds that second column ends after Hello.
+ * 
+ * Escaped Quotes (Accepted) ->
+ * 		"123466","Hello "Wor""ld","ABC" -> [123466, Hello Wor"ld, ABC]
+ * 		"123466","Hello "World""","ABC" -> [123466, Hello "World", ABC]
+ * </p>
+ * This tokenizer expects AlwaysQuoteMode() enabled
+ * @author Nilesh.Akhade
+ *
+ */
+public class RejectNonEscapedQuotesTokenizer extends AbstractTokenizer {
+
+	private static final char NEWLINE = '\n';
+	
+	private static final char SPACE = ' ';
+	
+	private final StringBuilder currentColumn = new StringBuilder();
+	
+	/* the raw, untokenized CSV row (may span multiple lines) */
+	private final StringBuilder currentRow = new StringBuilder();
+	
+	private final int quoteChar;
+	
+	private final int delimeterChar;
+	
+	private final boolean surroundingSpacesNeedQuotes;
+	
+	private final boolean ignoreEmptyLines;
+	
+	private final CommentMatcher commentMatcher;
+
+	private final int maxLinesPerRow;
+
+	//private QuoteMode quoteMode;
+	
+	/**
+	 * Enumeration of tokenizer states. QUOTE_MODE is activated between quotes.
+	 */
+	private enum TokenizerState {
+		NORMAL, QUOTE_MODE;
+	}
+	
+	public RejectNonEscapedQuotesTokenizer(Reader reader, CsvPreference preferences) {
+		super(reader, preferences);
+		this.quoteChar = preferences.getQuoteChar();
+		this.delimeterChar = preferences.getDelimiterChar();
+		this.surroundingSpacesNeedQuotes = preferences.isSurroundingSpacesNeedQuotes();
+		this.ignoreEmptyLines = preferences.isIgnoreEmptyLines();
+		this.commentMatcher = preferences.getCommentMatcher();
+		this.maxLinesPerRow = preferences.getMaxLinesPerRow();
+//		this.quoteMode = preferences.getQuoteMode();
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 */
+	public boolean readColumns(final List<String> columns) throws IOException {
+		
+		if( columns == null ) {
+			throw new NullPointerException("columns should not be null");
+		}
+		
+		// clear the reusable List and StringBuilders
+		columns.clear();
+		currentColumn.setLength(0);
+		currentRow.setLength(0);
+		
+		// read a line (ignoring empty lines/comments if necessary)
+		String line;
+		do {
+			line = readLine();
+			if( line == null ) {
+				return false; // EOF
+			}
+		}
+		while( ignoreEmptyLines && line.length() == 0 || (commentMatcher != null && commentMatcher.isComment(line)) );
+		
+		// update the untokenized CSV row
+		currentRow.append(line);
+		
+		// process each character in the line, catering for surrounding quotes (QUOTE_MODE)
+		TokenizerState state = TokenizerState.NORMAL;
+		int quoteScopeStartingLine = -1; // the line number where a potential multi-line cell starts
+		int potentialSpaces = 0; // keep track of spaces (so leading/trailing space can be removed if required)
+		int charIndex = 0;
+		while( true ) {
+			boolean endOfLineReached = charIndex == line.length();
+			
+			if( endOfLineReached )
+			{
+				if( TokenizerState.NORMAL.equals(state) ) {
+					/*
+					 * Newline. Add any required spaces (if surrounding spaces don't need quotes) and return (we've read
+					 * a line!).
+					 */
+					if( !surroundingSpacesNeedQuotes ) {
+						appendSpaces(currentColumn, potentialSpaces);
+					}
+					columns.add(currentColumn.length() > 0 ? currentColumn.toString() : null); // "" -> null
+					return true;
+				}
+				else
+				{
+					/*
+					 * Newline. Doesn't count as newline while in QUOTESCOPE. Add the newline char, reset the charIndex
+					 * (will update to 0 for next iteration), read in the next line, then then continue to next
+					 * character.
+					 */
+					currentColumn.append(NEWLINE);
+					currentRow.append(NEWLINE); // specific line terminator lost, \n will have to suffice
+					
+					charIndex = 0;
+
+					if (maxLinesPerRow > 0 && getLineNumber() - quoteScopeStartingLine + 1 >= maxLinesPerRow) {
+						/*
+						 * The quoted section that is being parsed spans too many lines, so to avoid excessive memory
+						 * usage parsing something that is probably human error anyways, throw an exception. If each
+						 * row is suppose to be a single line and this has been exceeded, throw a more descriptive
+						 * exception
+						 */
+						String msg = maxLinesPerRow == 1 ?
+								String.format("unexpected end of line while reading quoted column on line %d",
+											  getLineNumber()) :
+								String.format("max number of lines to read exceeded while reading quoted column" +
+											  " beginning on line %d and ending on line %d",
+											  quoteScopeStartingLine, getLineNumber());
+						throw new SuperCsvException(msg);
+					}
+					else if( (line = readLine()) == null ) {
+						throw new SuperCsvException(
+							String
+								.format(
+									"unexpected end of file while reading quoted column beginning on line %d and ending on line %d",
+									quoteScopeStartingLine, getLineNumber()));
+					}
+					
+					currentRow.append(line); // update untokenized CSV row
+					
+				    if (line.length() == 0){
+				    	// consecutive newlines
+                        continue;
+				    }
+				}
+			}
+			
+			final char c = line.charAt(charIndex);
+			
+			if( TokenizerState.NORMAL.equals(state) ) {
+				
+				/*
+				 * NORMAL mode (not within quotes).
+				 */
+				
+				if( c == delimeterChar ) {
+					/*
+					 * Delimiter. Save the column (trim trailing space if required) then continue to next character.
+					 */
+					if( !surroundingSpacesNeedQuotes ) {
+						appendSpaces(currentColumn, potentialSpaces);
+					}
+					columns.add(currentColumn.length() > 0 ? currentColumn.toString() : null); // "" -> null
+					potentialSpaces = 0;
+					currentColumn.setLength(0);
+					
+				} else if( c == SPACE ) {
+					/*
+					 * Space. Remember it, then continue to next character.
+					 */
+					potentialSpaces++;
+					
+				}
+				else if( c == quoteChar ) {
+					/*
+					 * A single quote ("). Update to QUOTESCOPE (but don't save quote), then continue to next character.
+					 */
+					state = TokenizerState.QUOTE_MODE;
+					quoteScopeStartingLine = getLineNumber();
+					
+					// cater for spaces before a quoted section (be lenient!)
+					if( !surroundingSpacesNeedQuotes || currentColumn.length() > 0 ) {
+						appendSpaces(currentColumn, potentialSpaces);
+					}
+					potentialSpaces = 0;
+					
+				} else {
+					/*
+					 * Just a normal character. Add any required spaces (but trim any leading spaces if surrounding
+					 * spaces need quotes), add the character, then continue to next character.
+					 */
+					if( !surroundingSpacesNeedQuotes || currentColumn.length() > 0 ) {
+						appendSpaces(currentColumn, potentialSpaces);
+					}
+					
+					potentialSpaces = 0;
+					currentColumn.append(c);
+				}
+				
+			} else {
+				
+				/*
+				 * QUOTE_MODE (within quotes).
+				 */
+				
+				if( c == quoteChar ) {
+					/*
+					 * (?) Thinking the edge case
+					 * "Hello World","Java"
+					 *                    ^
+					 *                 charIndex = 19
+					 *             line.length() = 20
+					 *       availableCharacters = false
+					 */
+					int nextCharIndex = charIndex + 1;
+					boolean availableCharacters = nextCharIndex < line.length();
+					boolean nextCharIsNotDelimiter = availableCharacters && line.charAt(nextCharIndex) != delimeterChar;
+					if( nextCharIsNotDelimiter) {
+						/*
+						 * Hello",orld  (case when nextCharIsNotDelimiter is false because nextChar is ,)
+						 * Hello""orld  (case when nextCharIsNotDelimiter is true because nextChar is ")
+						 * Hello"World  (case when nextCharIsNotDelimiter is true because nextChar is W)
+						 *      ^
+						 *   charIndex
+						 * We want to reject non escaped quotes. Hence if next character is not comma then
+						 * it must be quote(i.e, It should have been escaped, Hello""orld)
+						 */
+						
+						boolean nextCharIsQuote = line.charAt(nextCharIndex) == quoteChar;
+						if (nextCharIsQuote) {
+							/*
+							 * Hello""World  (case when nextCharIsQuote is true because nextChar is ")
+							 * This is escaped quote. Thats perfectly fine. We will increment charIndex so
+							 * as to skip extra quote.
+							 */
+							currentColumn.append(c);
+							charIndex++;
+						} else {
+							/*
+							 * Hello"World  (case when nextCharIsNotDelimiter is true because nextChar is W)
+							 * We should raise the exception.
+							 */
+							throw new SuperCsvException( "Unescaped double quotes found in this record" );
+						}
+						
+					} else {
+						/*
+						 * A single quote ("). Update to NORMAL (but don't save quote), then continue to next character.
+						 */
+						state = TokenizerState.NORMAL;
+						quoteScopeStartingLine = -1; // reset ready for next multi-line cell
+					}
+				} else {
+					/*
+					 * Just a normal character, delimiter (they don't count in QUOTESCOPE) or space. Add the character,
+					 * then continue to next character.
+					 */
+					currentColumn.append(c);
+				}
+			}
+			
+			charIndex++; // read next char of the line
+		}
+	}
+	
+	/**
+	 * Appends the required number of spaces to the StringBuilder.
+	 * 
+	 * @param sb
+	 *            the StringBuilder
+	 * @param spaces
+	 *            the required number of spaces to append
+	 */
+	private static void appendSpaces(final StringBuilder sb, final int spaces) {
+		for( int i = 0; i < spaces; i++ ) {
+			sb.append(SPACE);
+		}
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 */
+	public String getUntokenizedRow() {
+		return currentRow.toString();
+	}
+
+}

--- a/super-csv/src/main/java/org/supercsv/io/RejectNonEscapedQuotesTokenizer.java
+++ b/super-csv/src/main/java/org/supercsv/io/RejectNonEscapedQuotesTokenizer.java
@@ -10,21 +10,24 @@ import org.supercsv.io.AbstractTokenizer;
 import org.supercsv.prefs.CsvPreference;
 
 /**
- * As per RFC standard every quote in value must be escaped by another quote. i.e,<code> Hello "World" -> Hello ""World"" </code>
- * If file does not comply RFC, this tokenizer rejects that record.
+ * As per RFC 4180 every quote in value must be escaped by another quote. i.e,<code> Hello "World" -> Hello ""World"" </code>
+ * If file does not comply RFC, this tokenizer rejects that record. In other words, this is strict RFC tokenizer.
  * 
  * <p>
- * Example :
- * 	NonEscaped Quotes (Rejected) ->
- * 		"123466","Hello "World","ABC"
- * 		"123466",""Hello" World","ABC"
- * 		"123466","Hello",World","ABC" This is rejected. Tool finds that second column ends after Hello.
- * 
- * Escaped Quotes (Accepted) ->
- * 		"123466","Hello "Wor""ld","ABC" -> [123466, Hello Wor"ld, ABC]
- * 		"123466","Hello "World""","ABC" -> [123466, Hello "World", ABC]
+ * Example : <br>
+ * 	NonEscaped Quotes (Rejected)  <br>
+ * <code>
+ * 		"123466","Hello "World","ABC" <br>
+ * 		"123466",""Hello" World","ABC" <br>
+ * 		"123466","Hello",World","ABC" <br>
+ * </code>
+ * Escaped Quotes (Accepted)  <br>
+ * <code>
+ * 		"123466","Hello Wor""ld","ABC" -> [123466, Hello Wor"ld, ABC] <br>
+ * 		"123466","Hello ""World""","ABC" -> [123466, Hello "World", ABC] <br>
+ * </code>
  * </p>
- * This tokenizer expects AlwaysQuoteMode() enabled
+ * 
  * @author Nilesh.Akhade
  *
  */
@@ -159,10 +162,10 @@ public class RejectNonEscapedQuotesTokenizer extends AbstractTokenizer {
 					
 					currentRow.append(line); // update untokenized CSV row
 					
-				    if (line.length() == 0){
-				    	// consecutive newlines
-                        continue;
-				    }
+					if (line.length() == 0){
+						// consecutive newlines
+						continue;
+					}
 				}
 			}
 			
@@ -192,8 +195,7 @@ public class RejectNonEscapedQuotesTokenizer extends AbstractTokenizer {
 					 */
 					potentialSpaces++;
 					
-				}
-				else if( c == quoteChar ) {
+				} else if( c == quoteChar ) {
 					/*
 					 * A single quote ("). Update to QUOTESCOPE (but don't save quote), then continue to next character.
 					 */
@@ -227,7 +229,7 @@ public class RejectNonEscapedQuotesTokenizer extends AbstractTokenizer {
 				
 				if( c == quoteChar ) {
 					/*
-					 * (?) Thinking the edge case
+					 * Case when c is last char in line
 					 * "Hello World","Java"
 					 *                    ^
 					 *                 charIndex = 19

--- a/super-csv/src/test/java/org/supercsv/io/AllowNonEscapedTokenizerTest.java
+++ b/super-csv/src/test/java/org/supercsv/io/AllowNonEscapedTokenizerTest.java
@@ -1,0 +1,789 @@
+/*
+ * Copyright 2007 Kasper B. Graversen
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.supercsv.io;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.supercsv.prefs.CsvPreference.EXCEL_PREFERENCE;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.supercsv.comment.CommentMatches;
+import org.supercsv.comment.CommentStartsWith;
+import org.supercsv.exception.SuperCsvException;
+import org.supercsv.prefs.CsvPreference;
+
+public class AllowNonEscapedTokenizerTest {
+	
+	private static final CsvPreference NORMAL_PREFERENCE = EXCEL_PREFERENCE;
+	private static final CsvPreference SPACES_NEED_QUOTES_PREFERENCE = new CsvPreference.Builder(EXCEL_PREFERENCE)
+		.surroundingSpacesNeedQuotes(true).build();
+	private static final CsvPreference DONT_IGNORE_EMPTY_LINES_PREFERENCE = new CsvPreference.Builder(EXCEL_PREFERENCE)
+		.ignoreEmptyLines(false).build();
+	private static final CsvPreference PARSE_EMPTY_COLUMNS_AS_EMPTY_STRING_PREFERENCE = new CsvPreference.Builder(EXCEL_PREFERENCE)
+		.setEmptyColumnParsing(EmptyColumnParsing.ParseEmptyColumnsAsEmptyString).build();
+		
+	private AbstractTokenizer tokenizer;
+	private List<String> columns;
+	
+	/**
+	 * Sets up the columns List for the test.
+	 * 
+	 * @throws Exception
+	 */
+	@Before
+	public void setUp() {
+		columns = new ArrayList<String>();
+	}
+	
+	/**
+	 * Tidies up after the test.
+	 */
+	@After
+	public void tearDown() throws IOException {
+		if( tokenizer != null ) {
+			tokenizer.close();
+		}
+	}
+	
+	/**
+	 * Creates a Tokenizer with the input and preferences.
+	 * 
+	 * @param input
+	 *            the input String
+	 * @param preference
+	 *            the preferences
+	 * @return the Tokenizer
+	 */
+	private static AbstractTokenizer createTokenizer(String input, CsvPreference preference) {
+		final Reader r = input != null ? new StringReader(input) : null;
+		return new AllowNonEscapedQuotesTokenizer(r, preference);
+	}
+	
+	/**
+	 * Tests the constructor with a null Reader (should throw an Exception).
+	 */
+	@Test(expected = NullPointerException.class)
+	public void testConstructorWithNullReader() throws Exception {
+		createTokenizer(null, NORMAL_PREFERENCE);
+	}
+	
+	/**
+	 * Tests the constructor with a null CsvPreference (should throw an Exception).
+	 */
+	@Test(expected = NullPointerException.class)
+	public void testConstructorWithNullPreferences() throws Exception {
+		createTokenizer("", null);
+	}
+	
+	/**
+	 * Tests the readColumns() method with null List (should throw an Exception).
+	 */
+	@Test(expected = NullPointerException.class)
+	public void testReadColumnsWithNullList() throws Exception {
+		tokenizer = createTokenizer("", NORMAL_PREFERENCE);
+		tokenizer.readColumns(null);
+	}
+	
+	/**
+	 * Tests the getPreferences() method.
+	 */
+	@Test()
+	public void testGetPreferences() throws Exception {
+		tokenizer = createTokenizer("", NORMAL_PREFERENCE);
+		CsvPreference prefs = tokenizer.getPreferences();
+		assertEquals(NORMAL_PREFERENCE.getDelimiterChar(), prefs.getDelimiterChar());
+		assertEquals(NORMAL_PREFERENCE.getEndOfLineSymbols(), prefs.getEndOfLineSymbols());
+		assertEquals(NORMAL_PREFERENCE.getQuoteChar(), prefs.getQuoteChar());
+		assertEquals(NORMAL_PREFERENCE.isSurroundingSpacesNeedQuotes(), prefs.isSurroundingSpacesNeedQuotes());
+	}
+	
+	/**
+	 * Tests the readColumns() method with no data.
+	 */
+	@Test
+	public void testReadColumnsWithNoData() throws Exception {
+		final String input = "";
+		tokenizer = createTokenizer(input, NORMAL_PREFERENCE);
+		tokenizer.readColumns(columns);
+		assertTrue(columns.isEmpty());
+		assertEquals(input, tokenizer.getUntokenizedRow());
+	}
+	
+	/**
+	 * Tests that the readColumns() method skips over empty lines.
+	 */
+	@Test
+	public void testEmptyLines() throws Exception {
+		
+		final String input = "\n\nthis is the third line\n";
+		tokenizer = createTokenizer(input, NORMAL_PREFERENCE);
+		tokenizer.readColumns(columns);
+		assertTrue(columns.size() == 1);
+		assertEquals("this is the third line", columns.get(0));
+		assertEquals(3, tokenizer.getLineNumber());
+		assertEquals("this is the third line", tokenizer.getUntokenizedRow());
+	}
+	
+	/**
+	 * Tests that the readColumns() method doesn't skip over empty lines if the ignoreEmptyLines
+	 * preference is disabled.
+	 */
+	@Test
+	public void testEmptyLinesWithIgnoreEmptyLines() throws Exception {
+		
+		final String input = "\nthis is the second line\n\n";
+		tokenizer = createTokenizer(input, DONT_IGNORE_EMPTY_LINES_PREFERENCE);
+		tokenizer.readColumns(columns);
+		assertTrue(columns.size() == 1);
+		assertNull(columns.get(0));
+		assertEquals(1, tokenizer.getLineNumber());
+		assertEquals("", tokenizer.getUntokenizedRow());
+		
+		tokenizer.readColumns(columns);
+		assertTrue(columns.size() == 1);
+		assertEquals("this is the second line", columns.get(0));
+		assertEquals(2, tokenizer.getLineNumber());
+		assertEquals("this is the second line", tokenizer.getUntokenizedRow());
+		
+		tokenizer.readColumns(columns);
+		assertTrue(columns.size() == 1);
+		assertNull(columns.get(0));
+		assertEquals(3, tokenizer.getLineNumber());
+		assertEquals("", tokenizer.getUntokenizedRow());
+	}
+	
+	/**
+	 * Tests the readColumns() method a quoted section has text surrounding it. This is not technically valid CSV, but
+	 * the tokenizer is lenient enough to allow it (it will just keep it as it is).
+	 */
+	@Test
+	public void testQuotedFieldWithSurroundingText() throws Exception {
+		
+		final String input = "surrounding \"quoted\" text";
+		tokenizer = createTokenizer(input, NORMAL_PREFERENCE);
+		tokenizer.readColumns(columns);
+		assertTrue(columns.size() == 1);
+		assertEquals("surrounding \"quoted\" text", columns.get(0));
+		assertEquals(1, tokenizer.getLineNumber());
+		assertEquals(input, tokenizer.getUntokenizedRow());
+		
+		// same result when surrounding spaces require quotes
+		tokenizer = createTokenizer(input, SPACES_NEED_QUOTES_PREFERENCE);
+		tokenizer.readColumns(columns);
+		assertTrue(columns.size() == 1);
+		assertEquals("surrounding quoted text", columns.get(0));
+		assertEquals(1, tokenizer.getLineNumber());
+		assertEquals(input, tokenizer.getUntokenizedRow());
+	}
+	
+	/**
+	 * Tests the readColumns() method when a quoted section with text after it. This is not technically valid CSV, but
+	 * the tokenizer is lenient enough to allow it (it will just unescape the quoted section).
+	 */
+	@Test
+	public void testQuotedFieldWithTextAfter() throws Exception {
+		
+		// illegal char after quoted section
+		final String input = "\"quoted on 2 lines\nand afterward some\" text";
+		tokenizer = createTokenizer(input, NORMAL_PREFERENCE);
+		tokenizer.readColumns(columns);
+		assertEquals(1, columns.size());
+		assertEquals("\"quoted on 2 lines\nand afterward some\" text", columns.get(0));
+		assertEquals(2, tokenizer.getLineNumber());
+		assertEquals(input, tokenizer.getUntokenizedRow());
+		
+		// should have exactly the same result when surrounding spaces need quotes
+		tokenizer = createTokenizer(input, SPACES_NEED_QUOTES_PREFERENCE);
+		tokenizer.readColumns(columns);
+		assertEquals(1, columns.size());
+		assertEquals("\"quoted on 2 lines\nand afterward some\" text", columns.get(0));
+		assertEquals(2, tokenizer.getLineNumber());
+		assertEquals(input, tokenizer.getUntokenizedRow());
+	}
+	
+	/**
+	 * Tests the readColumns() method with a single quoted newline.
+	 */
+	@Test
+	public void testQuotedNewline() throws Exception {
+		
+		final String input = "\"\n\"";
+		tokenizer = createTokenizer(input, NORMAL_PREFERENCE);
+		tokenizer.readColumns(columns);
+		assertTrue(columns.size() == 1);
+		assertEquals("\n", columns.get(0));
+		assertEquals(input, tokenizer.getUntokenizedRow());
+		
+		// same input when surrounding spaces require quotes (results should be identical)
+		tokenizer = createTokenizer(input, SPACES_NEED_QUOTES_PREFERENCE);
+		tokenizer.readColumns(columns);
+		assertTrue(columns.size() == 1);
+		assertEquals("\n", columns.get(0));
+		assertEquals(input, tokenizer.getUntokenizedRow());
+	}
+	
+	/**
+	 * Tests the readColumns() method with a variety of quoted newlines.
+	 */
+	@Test
+	public void testQuotedNewlines() throws Exception {
+		
+		final String input = "\"one line\",\"two\nlines\",\"three\nlines\n!\"";
+		tokenizer = createTokenizer(input, NORMAL_PREFERENCE);
+		tokenizer.readColumns(columns);
+		assertTrue(columns.size() == 3);
+		assertEquals("one line", columns.get(0));
+		assertEquals("two\nlines", columns.get(1));
+		assertEquals("three\nlines\n!", columns.get(2));
+		assertEquals(input, tokenizer.getUntokenizedRow());
+		
+		// same input when surrounding spaces require quotes (results should be identical)
+		tokenizer = createTokenizer(input, SPACES_NEED_QUOTES_PREFERENCE);
+		tokenizer.readColumns(columns);
+		assertTrue(columns.size() == 3);
+		assertEquals("one line", columns.get(0));
+		assertEquals("two\nlines", columns.get(1));
+		assertEquals("three\nlines\n!", columns.get(2));
+		assertEquals(input, tokenizer.getUntokenizedRow());
+	}
+	
+	
+	/**
+	 * Tests the readColumns() method when a quoted field has consecutive newlines.
+	 */
+	@Test
+	public void testQuotedTextWithConsecutiveNewLines() throws Exception {
+		
+		// second field has consecutive newlines
+		final String input = "one, \"multiline\n\n\ntext\"";
+		tokenizer = createTokenizer(input, NORMAL_PREFERENCE);
+		tokenizer.readColumns(columns);
+		assertEquals(2, columns.size());
+		assertEquals("one", columns.get(0));
+		assertEquals(" multiline\n\n\ntext", columns.get(1));
+		assertEquals(4, tokenizer.getLineNumber());
+		assertEquals(input, tokenizer.getUntokenizedRow());
+		
+		// should have exactly the same result when surrounding spaces need quotes
+		tokenizer = createTokenizer(input, SPACES_NEED_QUOTES_PREFERENCE);
+		tokenizer.readColumns(columns);
+		assertTrue(columns.size() == 2);
+		assertEquals("one", columns.get(0));
+		assertEquals("multiline\n\n\ntext", columns.get(1));
+		assertEquals(input, tokenizer.getUntokenizedRow());
+	}
+	
+	/**
+	 * Tests the readColumns() method when EOF is reached within quote scope.
+	 */
+	@Test
+	public void testQuotedFieldWithUnexpectedEOF() throws Exception {
+		
+		// EOF reached within quote scope
+		final String input = "\"quoted spanning\ntwo lines with EOF reached before another quote";
+		tokenizer = createTokenizer(input, NORMAL_PREFERENCE);
+		try {
+			tokenizer.readColumns(columns);
+			fail("should have thrown SuperCsvException");
+		}
+		catch(SuperCsvException e) {
+			assertEquals("unexpected end of file while reading quoted column beginning on line 1 and ending on line 2",
+				e.getMessage());
+		}
+	}
+
+	/**
+	 * Tests the readColumns() method when a newline is reached in quote
+	 * scoped when a single line is only supposed to be read
+	 */
+	@Test
+	public void testQuotedFieldWithUnexpectedNewline() throws Exception {
+
+		// Row 2 has a missing trailing quote
+		final String input = "col1,col2\n" +
+				"\"foo\",\"bar\n" +
+				"\"baz\",\"zoo\"\n" +
+				"\"aaa\",\"bbb\"";
+		CsvPreference pref = new CsvPreference.Builder(NORMAL_PREFERENCE)
+				.maxLinesPerRow(1).build();
+
+		tokenizer = createTokenizer(input, pref);
+		try {
+			boolean first = tokenizer.readColumns(columns);
+			assertEquals(true , first);
+
+			tokenizer.readColumns(columns);
+			fail("should have thrown SuperCsvException");
+		}
+		catch(SuperCsvException e) {
+			assertEquals("unexpected end of line while reading quoted column on line 2",
+					e.getMessage());
+		}
+	}
+
+	/**
+	 * Tests the readColumns() method when a newline is reached in quote
+	 * scoped when two lines are only supposed to be read
+	 */
+	@Test
+	public void testQuotedFieldWithTwoMaxLines() throws Exception {
+
+		// Row 2 has a missing trailing quote
+		final String input = "col1,col2\n" +
+				"\"foo\",\"bar\n" +
+				"baz,zoo\n" +
+				"aaa,bbb";
+		CsvPreference pref = new CsvPreference.Builder(NORMAL_PREFERENCE)
+				.maxLinesPerRow(2).build();
+
+		tokenizer = createTokenizer(input, pref);
+		try {
+			boolean first = tokenizer.readColumns(columns);
+			assertEquals(true , first);
+
+			boolean second = tokenizer.readColumns(columns);
+			assertEquals(true , second);
+
+			tokenizer.readColumns(columns);
+			fail("should have thrown SuperCsvException");
+		}
+		catch(SuperCsvException e) {
+			assertEquals("max number of lines to read exceeded while reading quoted column beginning on line 2 and ending on line 3",
+					e.getMessage());
+		}
+	}
+
+	@Test
+	public void testQuotedFieldWithUnexpectedNewlineNoNextLineRead() throws Exception {
+
+		// Row 2 has a missing trailing quote
+		final String input = "col1,col2\n" +
+				"\"foo\",\"bar\n" +
+				"\"baz\",\"zoo\"\n" +
+				"\"aaa\",\"bbb\"";
+		CsvPreference pref = new CsvPreference.Builder(NORMAL_PREFERENCE)
+				.maxLinesPerRow(1).build();
+
+		tokenizer = createTokenizer(input, pref);
+		try {
+			final boolean first = tokenizer.readColumns(columns);
+			assertEquals(true , first);
+			assertEquals("[col1, col2]" , columns.toString());
+
+			tokenizer.readColumns(columns);
+			fail("should have thrown SuperCsvException");
+		}
+		catch(SuperCsvException e) {
+			assertEquals("unexpected end of line while reading quoted column on line 2",
+					e.getMessage());
+		}
+		final boolean third = tokenizer.readColumns(columns);
+		assertEquals(true , third);
+		assertEquals("[baz, zoo]" , columns.toString());
+
+		final boolean fourth = tokenizer.readColumns(columns);
+		assertEquals(true , fourth);
+		assertEquals("[aaa, bbb]" , columns.toString());
+
+		//line 4 was the last 
+		final boolean fifth = tokenizer.readColumns(columns);
+		assertEquals(false , fifth);
+	}
+
+	/**
+	 * Tests the readColumns() method when a newline is reached in quote
+	 * scoped when two lines are only supposed to be read
+	 */
+	@Test
+	public void testQuotedFieldWithTwoMaxLinesNoMoreLinesRead() throws Exception {
+
+		// Row 2 has a missing trailing quote
+		final String input = "col1,col2\n" +
+				"\"foo,bar\n" +
+				"baz,zoo\n" +
+				"aaa,bbb";
+		CsvPreference pref = new CsvPreference.Builder(NORMAL_PREFERENCE)
+				.maxLinesPerRow(2).build();
+
+		tokenizer = createTokenizer(input, pref);
+		try {
+			boolean first = tokenizer.readColumns(columns);
+			assertEquals(true , first);
+			assertEquals("[col1, col2]" , columns.toString());
+			
+
+			boolean second = tokenizer.readColumns(columns);
+			assertEquals(true , second);
+			assertEquals("[\"foo,bar]" , columns.toString());
+
+
+			tokenizer.readColumns(columns);
+			fail("should have thrown SuperCsvException");
+		}
+		catch(SuperCsvException e) {
+			assertEquals("max number of lines to read exceeded while reading quoted column beginning on line 2 and ending on line 3",
+					e.getMessage());
+		}
+		boolean fourth = tokenizer.readColumns(columns);
+		assertEquals(true , fourth);
+		assertEquals("[aaa, bbb]" , columns.toString());
+		
+	}
+
+	/**
+	 * Tests the readColumns() method with a leading space before the first quoted field. This is not technically valid
+	 * CSV, but the tokenizer is lenient enough to allow it. The leading spaces will be trimmed off when surrounding
+	 * spaces require quotes, otherwise they will be part of the field.
+	 */
+	@Test
+	public void testQuotedFirstFieldWithLeadingSpace() throws Exception {
+		
+		// leading spaces should be preserved
+		final String input = "  \"quoted with leading spaces\",two";
+		tokenizer = createTokenizer(input, NORMAL_PREFERENCE);
+		tokenizer.readColumns(columns);
+		assertTrue(columns.size() == 2);
+		assertEquals("  quoted with leading spaces", columns.get(0));
+		assertEquals("two", columns.get(1));
+		assertEquals(input, tokenizer.getUntokenizedRow());
+		
+		// same input when surrounding spaces require quotes (leading spaces trimmed)
+		tokenizer = createTokenizer(input, SPACES_NEED_QUOTES_PREFERENCE);
+		tokenizer.readColumns(columns);
+		assertTrue(columns.size() == 2);
+		assertEquals("quoted with leading spaces", columns.get(0));
+		assertEquals("two", columns.get(1));
+		assertEquals(input, tokenizer.getUntokenizedRow());
+	}
+	
+	/**
+	 * Tests the readColumns() method with a leading space before the last quoted field. This is not technically valid
+	 * CSV, but the tokenizer is lenient enough to allow it. The leading spaces will be trimmed off when surrounding
+	 * spaces require quotes, otherwise they will be part of the field.
+	 */
+	@Test
+	public void testQuotedLastFieldWithLeadingSpace() throws Exception {
+		
+		// last field has a leading space before quote (should be preserved)
+		final String input = "one,two,  \"quoted with leading spaces\"";
+		tokenizer = createTokenizer(input, NORMAL_PREFERENCE);
+		tokenizer.readColumns(columns);
+		assertTrue(columns.size() == 3);
+		assertEquals("one", columns.get(0));
+		assertEquals("two", columns.get(1));
+		assertEquals("  quoted with leading spaces", columns.get(2));
+		assertEquals(input, tokenizer.getUntokenizedRow());
+		
+		// leading space should be trimmed off
+		tokenizer = createTokenizer(input, SPACES_NEED_QUOTES_PREFERENCE);
+		tokenizer.readColumns(columns);
+		assertTrue(columns.size() == 3);
+		assertEquals("one", columns.get(0));
+		assertEquals("two", columns.get(1));
+		assertEquals("quoted with leading spaces", columns.get(2));
+		assertEquals(input, tokenizer.getUntokenizedRow());
+	}
+	
+	/**
+	 * Tests the readColumns() method with a trailing space after the first quoted field. This is not technically valid
+	 * CSV, but the tokenizer is lenient enough to allow it. The quotes will be part of the field.
+	 */
+	@Test
+	public void testQuotedFirstFieldWithTrailingSpace() throws Exception {
+		
+		// first field has a leading space before quote (should be preserved)
+		final String input = "\"quoted with trailing spaces\"  ,two";
+		tokenizer = createTokenizer(input, NORMAL_PREFERENCE);
+		tokenizer.readColumns(columns);
+		assertTrue(columns.size() == 2);
+		assertEquals("\"quoted with trailing spaces  ", columns.get(0));
+		assertEquals("two", columns.get(1));
+		assertEquals(input, tokenizer.getUntokenizedRow());
+		
+		// trailing spaces should be trimmed
+		tokenizer = createTokenizer(input, SPACES_NEED_QUOTES_PREFERENCE);
+		tokenizer.readColumns(columns);
+		assertTrue(columns.size() == 2);
+		assertEquals("\"quoted with trailing spaces", columns.get(0));
+		assertEquals("two", columns.get(1));
+		assertEquals(input, tokenizer.getUntokenizedRow());
+	}
+	
+	/**
+	 * Tests the readColumns() method with a trailing space after the last quoted field. This is not technically valid
+	 * CSV, but the tokenizer is lenient enough to allow it. The trailing spaces will be trimmed off when surrounding
+	 * spaces require quotes, otherwise they will be part of the field.
+	 */
+	@Test
+	public void testQuotedLastFieldWithTrailingSpace() throws Exception {
+		
+		// last field has a leading space before quote (should be preserved)
+		final String input = "one,two,\"quoted with trailing spaces\"  ";
+		tokenizer = createTokenizer(input, NORMAL_PREFERENCE);
+		tokenizer.readColumns(columns);
+		assertTrue(columns.size() == 3);
+		assertEquals("one", columns.get(0));
+		assertEquals("two", columns.get(1));
+		assertEquals("quoted with trailing spaces\"  ", columns.get(2));
+		assertEquals(input, tokenizer.getUntokenizedRow());
+		
+		// trailing spaces should be trimmed off
+		tokenizer = createTokenizer(input, SPACES_NEED_QUOTES_PREFERENCE);
+		tokenizer.readColumns(columns);
+		assertTrue(columns.size() == 3);
+		assertEquals("one", columns.get(0));
+		assertEquals("two", columns.get(1));
+		assertEquals("quoted with trailing spaces\"", columns.get(2));
+		assertEquals(input, tokenizer.getUntokenizedRow());
+	}
+	
+	/**
+	 * Tests the readColumns() method with a variety of quoted spaces.
+	 */
+	@Test
+	public void testQuotedSpaces() throws Exception {
+		
+		final String input = "\" one \",\"  two  \",\"   three   \"";
+		tokenizer = createTokenizer(input, NORMAL_PREFERENCE);
+		tokenizer.readColumns(columns);
+		assertTrue(columns.size() == 3);
+		assertEquals(" one ", columns.get(0));
+		assertEquals("  two  ", columns.get(1));
+		assertEquals("   three   ", columns.get(2));
+		assertEquals(input, tokenizer.getUntokenizedRow());
+		
+		// same input when surrounding spaces require quotes (results should be identical)
+		tokenizer = createTokenizer(input, SPACES_NEED_QUOTES_PREFERENCE);
+		tokenizer.readColumns(columns);
+		assertTrue(columns.size() == 3);
+		assertEquals(" one ", columns.get(0));
+		assertEquals("  two  ", columns.get(1));
+		assertEquals("   three   ", columns.get(2));
+		assertEquals(input, tokenizer.getUntokenizedRow());
+	}
+	
+	/**
+	 * Tests the readColumns() method with a variety of unquoted spaces.
+	 */
+	@Test
+	public void testSpaces() throws Exception {
+		
+		final String input = " one ,  two  ,   three   ";
+		tokenizer = createTokenizer(input, NORMAL_PREFERENCE);
+		tokenizer.readColumns(columns);
+		assertTrue(columns.size() == 3);
+		assertEquals(" one ", columns.get(0));
+		assertEquals("  two  ", columns.get(1));
+		assertEquals("   three   ", columns.get(2));
+		assertEquals(input, tokenizer.getUntokenizedRow());
+		
+		// same input when surrounding spaces require quotes
+		tokenizer = createTokenizer(input, SPACES_NEED_QUOTES_PREFERENCE);
+		tokenizer.readColumns(columns);
+		assertTrue(columns.size() == 3);
+		assertEquals("one", columns.get(0));
+		assertEquals("two", columns.get(1));
+		assertEquals("three", columns.get(2));
+		assertEquals(input, tokenizer.getUntokenizedRow());
+	}
+	
+	/**
+	 * Tests the readColumns() method with a variety of spaces and tabs.
+	 */
+	@Test
+	public void testSpacesAndTabs() throws Exception {
+		
+		// tabs should never be trimmed
+		final String input = "\t, \tone\t ,  \ttwo\t  ,   \tthree\t   ";
+		tokenizer = createTokenizer(input, NORMAL_PREFERENCE);
+		tokenizer.readColumns(columns);
+		assertTrue(columns.size() == 4);
+		assertEquals("\t", columns.get(0));
+		assertEquals(" \tone\t ", columns.get(1));
+		assertEquals("  \ttwo\t  ", columns.get(2));
+		assertEquals("   \tthree\t   ", columns.get(3));
+		assertEquals(input, tokenizer.getUntokenizedRow());
+		
+		// same input when surrounding spaces require quotes
+		tokenizer = createTokenizer(input, SPACES_NEED_QUOTES_PREFERENCE);
+		tokenizer.readColumns(columns);
+		assertTrue(columns.size() == 4);
+		assertEquals("\t", columns.get(0));
+		assertEquals("\tone\t", columns.get(1));
+		assertEquals("\ttwo\t", columns.get(2));
+		assertEquals("\tthree\t", columns.get(3));
+		assertEquals(input, tokenizer.getUntokenizedRow());
+	}
+	
+	/**
+	 * Tests the readColumns() method with spaces between words.
+	 */
+	@Test
+	public void testSpacesBetweenWords() throws Exception {
+		
+		final String input = " one partridge ,  two turtle doves  ,   three french hens   ";
+		tokenizer = createTokenizer(input, NORMAL_PREFERENCE);
+		tokenizer.readColumns(columns);
+		assertTrue(columns.size() == 3);
+		assertEquals(" one partridge ", columns.get(0));
+		assertEquals("  two turtle doves  ", columns.get(1));
+		assertEquals("   three french hens   ", columns.get(2));
+		assertEquals(input, tokenizer.getUntokenizedRow());
+		
+		// same input when surrounding spaces require quotes
+		tokenizer = createTokenizer(input, SPACES_NEED_QUOTES_PREFERENCE);
+		tokenizer.readColumns(columns);
+		assertTrue(columns.size() == 3);
+		assertEquals("one partridge", columns.get(0));
+		assertEquals("two turtle doves", columns.get(1));
+		assertEquals("three french hens", columns.get(2));
+		assertEquals(input, tokenizer.getUntokenizedRow());
+	}
+	
+	/**
+	 * Tests that the CommentStartsWith comment matcher works (comments are skipped).
+	 */
+	@Test
+	public void testSkipCommentsStartsWith() throws IOException {
+		
+		final CsvPreference commentsStartWithPrefs = new CsvPreference.Builder(EXCEL_PREFERENCE).skipComments(
+			new CommentStartsWith("#")).build();
+		
+		final String input = "#comment\nnot,a,comment\n# another comment\nalso,not,comment";
+		final AbstractTokenizer tokenizer = createTokenizer(input, commentsStartWithPrefs);
+		tokenizer.readColumns(columns);
+		assertTrue(columns.size() == 3);
+		assertEquals("not", columns.get(0));
+		assertEquals("a", columns.get(1));
+		assertEquals("comment", columns.get(2));
+		
+		tokenizer.readColumns(columns);
+		assertTrue(columns.size() == 3);
+		assertEquals("also", columns.get(0));
+		assertEquals("not", columns.get(1));
+		assertEquals("comment", columns.get(2));
+		
+		assertFalse(tokenizer.readColumns(columns));
+	}
+	
+	/**
+	 * Tests that the CommentMatches comment matcher works (comments are skipped).
+	 */
+	@Test
+	public void testSkipCommentsMatches() throws IOException {
+		
+		final CsvPreference commentsMatchesPrefs = new CsvPreference.Builder(EXCEL_PREFERENCE).skipComments(
+			new CommentMatches("<!--.*-->")).build();
+		
+		final String input = "<!--comment-->\nnot,a,comment\n<!-- another comment-->\nalso,not,comment";
+		final AbstractTokenizer tokenizer = createTokenizer(input, commentsMatchesPrefs);
+		tokenizer.readColumns(columns);
+		assertTrue(columns.size() == 3);
+		assertEquals("not", columns.get(0));
+		assertEquals("a", columns.get(1));
+		assertEquals("comment", columns.get(2));
+		
+		tokenizer.readColumns(columns);
+		assertTrue(columns.size() == 3);
+		assertEquals("also", columns.get(0));
+		assertEquals("not", columns.get(1));
+		assertEquals("comment", columns.get(2));
+		
+		assertFalse(tokenizer.readColumns(columns));
+		
+	}
+	
+	/**
+	 * Tests that the readColumns() method reads a null column as null when preferences is ParseEmptyColumnsAsNull.
+	 */
+	@Test
+	public void testReadNullWithParseEmptyColumnsAsNull() throws Exception {
+		
+		final String input = ",";
+		tokenizer = createTokenizer(input, NORMAL_PREFERENCE);
+		assertTrue(NORMAL_PREFERENCE.getEmptyColumnParsing().equals(EmptyColumnParsing.ParseEmptyColumnsAsNull));
+		
+		tokenizer.readColumns(columns);
+		assertTrue(columns.size() == 2);
+		assertEquals(",", tokenizer.getUntokenizedRow());
+		assertEquals(null, columns.get(0));
+		assertEquals(null, columns.get(1));
+	}
+	
+
+	/**
+	 * Tests that the readColumns() method reads an empty string column as null when preferences is ParseEmptyColumnsAsNull.
+	 */
+	@Test
+	public void testReadEmptyStringsWithParseEmptyColumnsAsNull() throws Exception {
+		
+		final String input = "\"\",\"\"";
+		tokenizer = createTokenizer(input, NORMAL_PREFERENCE);
+		assertTrue(NORMAL_PREFERENCE.getEmptyColumnParsing().equals(EmptyColumnParsing.ParseEmptyColumnsAsNull));
+		
+		tokenizer.readColumns(columns);
+		assertTrue(columns.size() == 2);
+		assertEquals("\"\",\"\"", tokenizer.getUntokenizedRow());
+		assertEquals(null, columns.get(0));
+		assertEquals(null, columns.get(1));
+	}
+	
+	/**
+	 * Tests that the readColumns() method reads a null column as null when preferences is ParseEmptyColumnsAsEmptyString.
+	 */
+	@Test
+	public void testReadNullWithParseEmptyColumnsAsEmptyString() throws Exception {
+		
+		final String input = ",";
+		tokenizer = createTokenizer(input, PARSE_EMPTY_COLUMNS_AS_EMPTY_STRING_PREFERENCE);
+		assertTrue(PARSE_EMPTY_COLUMNS_AS_EMPTY_STRING_PREFERENCE.getEmptyColumnParsing().equals(EmptyColumnParsing.ParseEmptyColumnsAsEmptyString));
+		
+		tokenizer.readColumns(columns);
+		assertTrue(columns.size() == 2);
+		assertEquals(",", tokenizer.getUntokenizedRow());
+		assertEquals(null, columns.get(0));
+		assertEquals(null, columns.get(1));
+	}
+	
+	/**
+	 * Tests that the readColumns() method reads an empty string column as empty string when preferences is ParseEmptyColumnsAsEmptyString.
+	 */
+	@Test
+	public void testReadEmptyStringsWithParseEmptyColumnsAsEmptyString() throws Exception {
+		
+		final String input = "\"\",\"\"";
+		tokenizer = createTokenizer(input, PARSE_EMPTY_COLUMNS_AS_EMPTY_STRING_PREFERENCE);
+		assertTrue(PARSE_EMPTY_COLUMNS_AS_EMPTY_STRING_PREFERENCE.getEmptyColumnParsing().equals(EmptyColumnParsing.ParseEmptyColumnsAsEmptyString));
+		
+		tokenizer.readColumns(columns);
+		assertTrue(columns.size() == 2);
+		assertEquals("\"\",\"\"", tokenizer.getUntokenizedRow());
+		assertEquals("", columns.get(0));
+		assertEquals("", columns.get(1));
+	}	
+	
+}

--- a/super-csv/src/test/java/org/supercsv/io/RejectNonEscapedQuotesTokenizerTest.java
+++ b/super-csv/src/test/java/org/supercsv/io/RejectNonEscapedQuotesTokenizerTest.java
@@ -1,0 +1,811 @@
+/*
+ * Copyright 2007 Kasper B. Graversen
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.supercsv.io;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.supercsv.prefs.CsvPreference.EXCEL_PREFERENCE;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.supercsv.comment.CommentMatches;
+import org.supercsv.comment.CommentStartsWith;
+import org.supercsv.exception.SuperCsvException;
+import org.supercsv.prefs.CsvPreference;
+
+public class RejectNonEscapedQuotesTokenizerTest {
+	
+	private static final CsvPreference NORMAL_PREFERENCE = EXCEL_PREFERENCE;
+	private static final CsvPreference SPACES_NEED_QUOTES_PREFERENCE = new CsvPreference.Builder(EXCEL_PREFERENCE)
+		.surroundingSpacesNeedQuotes(true).build();
+	private static final CsvPreference DONT_IGNORE_EMPTY_LINES_PREFERENCE = new CsvPreference.Builder(EXCEL_PREFERENCE)
+		.ignoreEmptyLines(false).build();
+	private static final CsvPreference PARSE_EMPTY_COLUMNS_AS_EMPTY_STRING_PREFERENCE = new CsvPreference.Builder(EXCEL_PREFERENCE)
+		.setEmptyColumnParsing(EmptyColumnParsing.ParseEmptyColumnsAsEmptyString).build();
+		
+	private AbstractTokenizer tokenizer;
+	private List<String> columns;
+	
+	/**
+	 * Sets up the columns List for the test.
+	 * 
+	 * @throws Exception
+	 */
+	@Before
+	public void setUp() {
+		columns = new ArrayList<String>();
+	}
+	
+	/**
+	 * Tidies up after the test.
+	 */
+	@After
+	public void tearDown() throws IOException {
+		if( tokenizer != null ) {
+			tokenizer.close();
+		}
+	}
+	
+	/**
+	 * Creates a Tokenizer with the input and preferences.
+	 * 
+	 * @param input
+	 *            the input String
+	 * @param preference
+	 *            the preferences
+	 * @return the Tokenizer
+	 */
+	private static AbstractTokenizer createTokenizer(String input, CsvPreference preference) {
+		final Reader r = input != null ? new StringReader(input) : null;
+		return new RejectNonEscapedQuotesTokenizer(r, preference);
+	}
+	
+	/**
+	 * Tests the constructor with a null Reader (should throw an Exception).
+	 */
+	@Test(expected = NullPointerException.class)
+	public void testConstructorWithNullReader() throws Exception {
+		createTokenizer(null, NORMAL_PREFERENCE);
+	}
+	
+	/**
+	 * Tests the constructor with a null CsvPreference (should throw an Exception).
+	 */
+	@Test(expected = NullPointerException.class)
+	public void testConstructorWithNullPreferences() throws Exception {
+		createTokenizer("", null);
+	}
+	
+	/**
+	 * Tests the readColumns() method with null List (should throw an Exception).
+	 */
+	@Test(expected = NullPointerException.class)
+	public void testReadColumnsWithNullList() throws Exception {
+		tokenizer = createTokenizer("", NORMAL_PREFERENCE);
+		tokenizer.readColumns(null);
+	}
+	
+	/**
+	 * Tests the getPreferences() method.
+	 */
+	@Test()
+	public void testGetPreferences() throws Exception {
+		tokenizer = createTokenizer("", NORMAL_PREFERENCE);
+		CsvPreference prefs = tokenizer.getPreferences();
+		assertEquals(NORMAL_PREFERENCE.getDelimiterChar(), prefs.getDelimiterChar());
+		assertEquals(NORMAL_PREFERENCE.getEndOfLineSymbols(), prefs.getEndOfLineSymbols());
+		assertEquals(NORMAL_PREFERENCE.getQuoteChar(), prefs.getQuoteChar());
+		assertEquals(NORMAL_PREFERENCE.isSurroundingSpacesNeedQuotes(), prefs.isSurroundingSpacesNeedQuotes());
+	}
+	
+	/**
+	 * Tests the readColumns() method with no data.
+	 */
+	@Test
+	public void testReadColumnsWithNoData() throws Exception {
+		final String input = "";
+		tokenizer = createTokenizer(input, NORMAL_PREFERENCE);
+		tokenizer.readColumns(columns);
+		assertTrue(columns.isEmpty());
+		assertEquals(input, tokenizer.getUntokenizedRow());
+	}
+	
+	/**
+	 * Tests that the readColumns() method skips over empty lines.
+	 */
+	@Test
+	public void testEmptyLines() throws Exception {
+		
+		final String input = "\n\nthis is the third line\n";
+		tokenizer = createTokenizer(input, NORMAL_PREFERENCE);
+		tokenizer.readColumns(columns);
+		assertTrue(columns.size() == 1);
+		assertEquals("this is the third line", columns.get(0));
+		assertEquals(3, tokenizer.getLineNumber());
+		assertEquals("this is the third line", tokenizer.getUntokenizedRow());
+	}
+	
+	/**
+	 * Tests that the readColumns() method doesn't skip over empty lines if the ignoreEmptyLines
+	 * preference is disabled.
+	 */
+	@Test
+	public void testEmptyLinesWithIgnoreEmptyLines() throws Exception {
+		
+		final String input = "\nthis is the second line\n\n";
+		tokenizer = createTokenizer(input, DONT_IGNORE_EMPTY_LINES_PREFERENCE);
+		tokenizer.readColumns(columns);
+		assertTrue(columns.size() == 1);
+		assertNull(columns.get(0));
+		assertEquals(1, tokenizer.getLineNumber());
+		assertEquals("", tokenizer.getUntokenizedRow());
+		
+		tokenizer.readColumns(columns);
+		assertTrue(columns.size() == 1);
+		assertEquals("this is the second line", columns.get(0));
+		assertEquals(2, tokenizer.getLineNumber());
+		assertEquals("this is the second line", tokenizer.getUntokenizedRow());
+		
+		tokenizer.readColumns(columns);
+		assertTrue(columns.size() == 1);
+		assertNull(columns.get(0));
+		assertEquals(3, tokenizer.getLineNumber());
+		assertEquals("", tokenizer.getUntokenizedRow());
+	}
+	
+	/**
+	 * Tests the readColumns() method a quoted section has text surrounding it. This is not technically valid CSV,
+	 * hence the tokenizer will reject this record.
+	 */
+	@Test
+	public void testQuotedFieldWithSurroundingText() throws Exception {
+		
+		final String input = "surrounding \"quoted\" text";
+		tokenizer = createTokenizer(input, NORMAL_PREFERENCE);
+		try {
+			tokenizer.readColumns(columns);
+			fail("should have thrown SuperCsvException");
+		}
+		catch(SuperCsvException e) {
+			assertEquals("Unescaped double quotes found in this record",
+				e.getMessage());
+		}
+		
+		// same result when surrounding spaces require quotes
+		tokenizer = createTokenizer(input, SPACES_NEED_QUOTES_PREFERENCE);
+		try {
+			tokenizer.readColumns(columns);
+			fail("should have thrown SuperCsvException");
+		}
+		catch(SuperCsvException e) {
+			assertEquals("Unescaped double quotes found in this record",
+				e.getMessage());
+		}
+	}
+	
+	/**
+	 * Tests the readColumns() method when a quoted section with text after it. This is not technically valid CSV,
+	 * hence the tokenizer will reject this record
+	 */
+	@Test
+	public void testQuotedFieldWithTextAfter() throws Exception {
+		
+		// illegal char after quoted section
+		final String input = "\"quoted on 2 lines\nand afterward some\" text";
+		tokenizer = createTokenizer(input, NORMAL_PREFERENCE);
+		try {
+			tokenizer.readColumns(columns);
+			fail("should have thrown SuperCsvException");
+		}
+		catch(SuperCsvException e) {
+			assertEquals("Unescaped double quotes found in this record",
+				e.getMessage());
+		}
+		
+		// should have exactly the same result when surrounding spaces need quotes
+		tokenizer = createTokenizer(input, SPACES_NEED_QUOTES_PREFERENCE);
+		try {
+			tokenizer.readColumns(columns);
+			fail("should have thrown SuperCsvException");
+		}
+		catch(SuperCsvException e) {
+			assertEquals("Unescaped double quotes found in this record",
+				e.getMessage());
+		}
+	}
+	
+	/**
+	 * Tests the readColumns() method with a single quoted newline.
+	 */
+	@Test
+	public void testQuotedNewline() throws Exception {
+		
+		final String input = "\"\n\"";
+		tokenizer = createTokenizer(input, NORMAL_PREFERENCE);
+		tokenizer.readColumns(columns);
+		assertTrue(columns.size() == 1);
+		assertEquals("\n", columns.get(0));
+		assertEquals(input, tokenizer.getUntokenizedRow());
+		
+		// same input when surrounding spaces require quotes (results should be identical)
+		tokenizer = createTokenizer(input, SPACES_NEED_QUOTES_PREFERENCE);
+		tokenizer.readColumns(columns);
+		assertTrue(columns.size() == 1);
+		assertEquals("\n", columns.get(0));
+		assertEquals(input, tokenizer.getUntokenizedRow());
+	}
+	
+	/**
+	 * Tests the readColumns() method with a variety of quoted newlines.
+	 */
+	@Test
+	public void testQuotedNewlines() throws Exception {
+		
+		final String input = "\"one line\",\"two\nlines\",\"three\nlines\n!\"";
+		tokenizer = createTokenizer(input, NORMAL_PREFERENCE);
+		tokenizer.readColumns(columns);
+		assertTrue(columns.size() == 3);
+		assertEquals("one line", columns.get(0));
+		assertEquals("two\nlines", columns.get(1));
+		assertEquals("three\nlines\n!", columns.get(2));
+		assertEquals(input, tokenizer.getUntokenizedRow());
+		
+		// same input when surrounding spaces require quotes (results should be identical)
+		tokenizer = createTokenizer(input, SPACES_NEED_QUOTES_PREFERENCE);
+		tokenizer.readColumns(columns);
+		assertTrue(columns.size() == 3);
+		assertEquals("one line", columns.get(0));
+		assertEquals("two\nlines", columns.get(1));
+		assertEquals("three\nlines\n!", columns.get(2));
+		assertEquals(input, tokenizer.getUntokenizedRow());
+	}
+	
+	
+	/**
+	 * Tests the readColumns() method when a quoted field has consecutive newlines.
+	 */
+	@Test
+	public void testQuotedTextWithConsecutiveNewLines() throws Exception {
+		
+		// second field has consecutive newlines
+		final String input = "one, \"multiline\n\n\ntext\"";
+		tokenizer = createTokenizer(input, NORMAL_PREFERENCE);
+		tokenizer.readColumns(columns);
+		assertEquals(2, columns.size());
+		assertEquals("one", columns.get(0));
+		assertEquals(" multiline\n\n\ntext", columns.get(1));
+		assertEquals(4, tokenizer.getLineNumber());
+		assertEquals(input, tokenizer.getUntokenizedRow());
+		
+		// should have exactly the same result when surrounding spaces need quotes
+		tokenizer = createTokenizer(input, SPACES_NEED_QUOTES_PREFERENCE);
+		tokenizer.readColumns(columns);
+		assertTrue(columns.size() == 2);
+		assertEquals("one", columns.get(0));
+		assertEquals("multiline\n\n\ntext", columns.get(1));
+		assertEquals(input, tokenizer.getUntokenizedRow());
+	}
+	
+	/**
+	 * Tests the readColumns() method when EOF is reached within quote scope.
+	 */
+	@Test
+	public void testQuotedFieldWithUnexpectedEOF() throws Exception {
+		
+		// EOF reached within quote scope
+		final String input = "\"quoted spanning\ntwo lines with EOF reached before another quote";
+		tokenizer = createTokenizer(input, NORMAL_PREFERENCE);
+		try {
+			tokenizer.readColumns(columns);
+			fail("should have thrown SuperCsvException");
+		}
+		catch(SuperCsvException e) {
+			assertEquals("unexpected end of file while reading quoted column beginning on line 1 and ending on line 2",
+				e.getMessage());
+		}
+	}
+
+	/**
+	 * Tests the readColumns() method when a newline is reached in quote
+	 * scoped when a single line is only supposed to be read
+	 */
+	@Test
+	public void testQuotedFieldWithUnexpectedNewline() throws Exception {
+
+		// Row 2 has a missing trailing quote
+		final String input = "col1,col2\n" +
+				"\"foo\",\"bar\n" +
+				"\"baz\",\"zoo\"\n" +
+				"\"aaa\",\"bbb\"";
+		CsvPreference pref = new CsvPreference.Builder(NORMAL_PREFERENCE)
+				.maxLinesPerRow(1).build();
+
+		tokenizer = createTokenizer(input, pref);
+		try {
+			boolean first = tokenizer.readColumns(columns);
+			assertEquals(true , first);
+
+			tokenizer.readColumns(columns);
+			fail("should have thrown SuperCsvException");
+		}
+		catch(SuperCsvException e) {
+			assertEquals("unexpected end of line while reading quoted column on line 2",
+					e.getMessage());
+		}
+	}
+
+	/**
+	 * Tests the readColumns() method when a newline is reached in quote
+	 * scoped when two lines are only supposed to be read
+	 */
+	@Test
+	public void testQuotedFieldWithTwoMaxLines() throws Exception {
+
+		// Row 2 has a missing trailing quote
+		final String input = "col1,col2\n" +
+				"\"foo\",\"bar\n" +
+				"baz,zoo\n" +
+				"aaa,bbb";
+		CsvPreference pref = new CsvPreference.Builder(NORMAL_PREFERENCE)
+				.maxLinesPerRow(2).build();
+
+		tokenizer = createTokenizer(input, pref);
+		try {
+			boolean first = tokenizer.readColumns(columns);
+			assertEquals(true , first);
+
+			boolean second = tokenizer.readColumns(columns);
+			assertEquals(true , second);
+
+			tokenizer.readColumns(columns);
+			fail("should have thrown SuperCsvException");
+		}
+		catch(SuperCsvException e) {
+			assertEquals("max number of lines to read exceeded while reading quoted column beginning on line 2 and ending on line 3",
+					e.getMessage());
+		}
+	}
+
+	@Test
+	public void testQuotedFieldWithUnexpectedNewlineNoNextLineRead() throws Exception {
+
+		// Row 2 has a missing trailing quote
+		final String input = "col1,col2\n" +
+				"\"foo\",\"bar\n" +
+				"\"baz\",\"zoo\"\n" +
+				"\"aaa\",\"bbb\"";
+		CsvPreference pref = new CsvPreference.Builder(NORMAL_PREFERENCE)
+				.maxLinesPerRow(1).build();
+
+		tokenizer = createTokenizer(input, pref);
+		try {
+			final boolean first = tokenizer.readColumns(columns);
+			assertEquals(true , first);
+			assertEquals("[col1, col2]" , columns.toString());
+
+			tokenizer.readColumns(columns);
+			fail("should have thrown SuperCsvException");
+		}
+		catch(SuperCsvException e) {
+			assertEquals("unexpected end of line while reading quoted column on line 2",
+					e.getMessage());
+		}
+		final boolean third = tokenizer.readColumns(columns);
+		assertEquals(true , third);
+		assertEquals("[baz, zoo]" , columns.toString());
+
+		final boolean fourth = tokenizer.readColumns(columns);
+		assertEquals(true , fourth);
+		assertEquals("[aaa, bbb]" , columns.toString());
+
+		//line 4 was the last 
+		final boolean fifth = tokenizer.readColumns(columns);
+		assertEquals(false , fifth);
+	}
+
+	/**
+	 * Tests the readColumns() method when a newline is reached in quote
+	 * scoped when two lines are only supposed to be read
+	 */
+	@Test
+	public void testQuotedFieldWithTwoMaxLinesNoMoreLinesRead() throws Exception {
+
+		// Row 2 has a missing trailing quote
+		final String input = "col1,col2\n" +
+				"\"foo,bar\n" +
+				"baz,zoo\n" +
+				"aaa,bbb";
+		CsvPreference pref = new CsvPreference.Builder(NORMAL_PREFERENCE)
+				.maxLinesPerRow(2).build();
+
+		tokenizer = createTokenizer(input, pref);
+		try {
+			boolean first = tokenizer.readColumns(columns);
+			assertEquals(true , first);
+			assertEquals("[col1, col2]" , columns.toString());
+			
+
+			boolean second = tokenizer.readColumns(columns);
+			assertEquals(true , second);
+			assertEquals("[\"foo,bar]" , columns.toString());
+
+
+			tokenizer.readColumns(columns);
+			fail("should have thrown SuperCsvException");
+		}
+		catch(SuperCsvException e) {
+			assertEquals("max number of lines to read exceeded while reading quoted column beginning on line 2 and ending on line 3",
+					e.getMessage());
+		}
+		boolean fourth = tokenizer.readColumns(columns);
+		assertEquals(true , fourth);
+		assertEquals("[aaa, bbb]" , columns.toString());
+		
+	}
+
+	/**
+	 * Tests the readColumns() method with a leading space before the first quoted field. This is not technically valid
+	 * CSV, but the tokenizer is lenient enough to allow it. The leading spaces will be trimmed off when surrounding
+	 * spaces require quotes, otherwise they will be part of the field.
+	 */
+	@Test
+	public void testQuotedFirstFieldWithLeadingSpace() throws Exception {
+		
+		// leading spaces should be preserved
+		final String input = "  \"quoted with leading spaces\",two";
+		tokenizer = createTokenizer(input, NORMAL_PREFERENCE);
+		tokenizer.readColumns(columns);
+		assertTrue(columns.size() == 2);
+		assertEquals("  quoted with leading spaces", columns.get(0));
+		assertEquals("two", columns.get(1));
+		assertEquals(input, tokenizer.getUntokenizedRow());
+		
+		// same input when surrounding spaces require quotes (leading spaces trimmed)
+		tokenizer = createTokenizer(input, SPACES_NEED_QUOTES_PREFERENCE);
+		tokenizer.readColumns(columns);
+		assertTrue(columns.size() == 2);
+		assertEquals("quoted with leading spaces", columns.get(0));
+		assertEquals("two", columns.get(1));
+		assertEquals(input, tokenizer.getUntokenizedRow());
+	}
+	
+	/**
+	 * Tests the readColumns() method with a leading space before the last quoted field. This is not technically valid
+	 * CSV, but the tokenizer is lenient enough to allow it. The leading spaces will be trimmed off when surrounding
+	 * spaces require quotes, otherwise they will be part of the field.
+	 */
+	@Test
+	public void testQuotedLastFieldWithLeadingSpace() throws Exception {
+		
+		// last field has a leading space before quote (should be preserved)
+		final String input = "one,two,  \"quoted with leading spaces\"";
+		tokenizer = createTokenizer(input, NORMAL_PREFERENCE);
+		tokenizer.readColumns(columns);
+		assertTrue(columns.size() == 3);
+		assertEquals("one", columns.get(0));
+		assertEquals("two", columns.get(1));
+		assertEquals("  quoted with leading spaces", columns.get(2));
+		assertEquals(input, tokenizer.getUntokenizedRow());
+		
+		// leading space should be trimmed off
+		tokenizer = createTokenizer(input, SPACES_NEED_QUOTES_PREFERENCE);
+		tokenizer.readColumns(columns);
+		assertTrue(columns.size() == 3);
+		assertEquals("one", columns.get(0));
+		assertEquals("two", columns.get(1));
+		assertEquals("quoted with leading spaces", columns.get(2));
+		assertEquals(input, tokenizer.getUntokenizedRow());
+	}
+	
+	/**
+	 * Tests the readColumns() method with a trailing space after the first quoted field. This is not technically valid
+	 * CSV, hence the tokenizer will reject it.
+	 */
+	@Test
+	public void testQuotedFirstFieldWithTrailingSpace() throws Exception {
+		
+		// first field has a leading space before quote (should be preserved)
+		final String input = "\"quoted with trailing spaces\"  ,two";
+		tokenizer = createTokenizer(input, NORMAL_PREFERENCE);
+		try {
+			tokenizer.readColumns(columns);
+			fail("should have thrown SuperCsvException");
+		}
+		catch(SuperCsvException e) {
+			assertEquals("Unescaped double quotes found in this record",
+				e.getMessage());
+		}
+		
+		// trailing spaces should be trimmed
+		tokenizer = createTokenizer(input, SPACES_NEED_QUOTES_PREFERENCE);
+		try {
+			tokenizer.readColumns(columns);
+			fail("should have thrown SuperCsvException");
+		}
+		catch(SuperCsvException e) {
+			assertEquals("Unescaped double quotes found in this record",
+				e.getMessage());
+		}
+	}
+	
+	/**
+	 * Tests the readColumns() method with a trailing space after the last quoted field. This is not technically valid
+	 * CSV, hence the tokenizer is lenient enough to allow it. The trailing spaces will be trimmed off when surrounding
+	 * spaces require quotes, otherwise they will be part of the field.
+	 */
+	@Test
+	public void testQuotedLastFieldWithTrailingSpace() throws Exception {
+		
+		// last field has a leading space before quote (should be preserved)
+		final String input = "one,two,\"quoted with trailing spaces\"  ";
+		tokenizer = createTokenizer(input, NORMAL_PREFERENCE);
+		try {
+			tokenizer.readColumns(columns);
+			fail("should have thrown SuperCsvException");
+		}
+		catch(SuperCsvException e) {
+			assertEquals("Unescaped double quotes found in this record",
+				e.getMessage());
+		}
+		
+		// trailing spaces should be trimmed off
+		tokenizer = createTokenizer(input, SPACES_NEED_QUOTES_PREFERENCE);
+		try {
+			tokenizer.readColumns(columns);
+			fail("should have thrown SuperCsvException");
+		}
+		catch(SuperCsvException e) {
+			assertEquals("Unescaped double quotes found in this record",
+				e.getMessage());
+		}
+	}
+	
+	/**
+	 * Tests the readColumns() method with a variety of quoted spaces.
+	 */
+	@Test
+	public void testQuotedSpaces() throws Exception {
+		
+		final String input = "\" one \",\"  two  \",\"   three   \"";
+		tokenizer = createTokenizer(input, NORMAL_PREFERENCE);
+		tokenizer.readColumns(columns);
+		assertTrue(columns.size() == 3);
+		assertEquals(" one ", columns.get(0));
+		assertEquals("  two  ", columns.get(1));
+		assertEquals("   three   ", columns.get(2));
+		assertEquals(input, tokenizer.getUntokenizedRow());
+		
+		// same input when surrounding spaces require quotes (results should be identical)
+		tokenizer = createTokenizer(input, SPACES_NEED_QUOTES_PREFERENCE);
+		tokenizer.readColumns(columns);
+		assertTrue(columns.size() == 3);
+		assertEquals(" one ", columns.get(0));
+		assertEquals("  two  ", columns.get(1));
+		assertEquals("   three   ", columns.get(2));
+		assertEquals(input, tokenizer.getUntokenizedRow());
+	}
+	
+	/**
+	 * Tests the readColumns() method with a variety of unquoted spaces.
+	 */
+	@Test
+	public void testSpaces() throws Exception {
+		
+		final String input = " one ,  two  ,   three   ";
+		tokenizer = createTokenizer(input, NORMAL_PREFERENCE);
+		tokenizer.readColumns(columns);
+		assertTrue(columns.size() == 3);
+		assertEquals(" one ", columns.get(0));
+		assertEquals("  two  ", columns.get(1));
+		assertEquals("   three   ", columns.get(2));
+		assertEquals(input, tokenizer.getUntokenizedRow());
+		
+		// same input when surrounding spaces require quotes
+		tokenizer = createTokenizer(input, SPACES_NEED_QUOTES_PREFERENCE);
+		tokenizer.readColumns(columns);
+		assertTrue(columns.size() == 3);
+		assertEquals("one", columns.get(0));
+		assertEquals("two", columns.get(1));
+		assertEquals("three", columns.get(2));
+		assertEquals(input, tokenizer.getUntokenizedRow());
+	}
+	
+	/**
+	 * Tests the readColumns() method with a variety of spaces and tabs.
+	 */
+	@Test
+	public void testSpacesAndTabs() throws Exception {
+		
+		// tabs should never be trimmed
+		final String input = "\t, \tone\t ,  \ttwo\t  ,   \tthree\t   ";
+		tokenizer = createTokenizer(input, NORMAL_PREFERENCE);
+		tokenizer.readColumns(columns);
+		assertTrue(columns.size() == 4);
+		assertEquals("\t", columns.get(0));
+		assertEquals(" \tone\t ", columns.get(1));
+		assertEquals("  \ttwo\t  ", columns.get(2));
+		assertEquals("   \tthree\t   ", columns.get(3));
+		assertEquals(input, tokenizer.getUntokenizedRow());
+		
+		// same input when surrounding spaces require quotes
+		tokenizer = createTokenizer(input, SPACES_NEED_QUOTES_PREFERENCE);
+		tokenizer.readColumns(columns);
+		assertTrue(columns.size() == 4);
+		assertEquals("\t", columns.get(0));
+		assertEquals("\tone\t", columns.get(1));
+		assertEquals("\ttwo\t", columns.get(2));
+		assertEquals("\tthree\t", columns.get(3));
+		assertEquals(input, tokenizer.getUntokenizedRow());
+	}
+	
+	/**
+	 * Tests the readColumns() method with spaces between words.
+	 */
+	@Test
+	public void testSpacesBetweenWords() throws Exception {
+		
+		final String input = " one partridge ,  two turtle doves  ,   three french hens   ";
+		tokenizer = createTokenizer(input, NORMAL_PREFERENCE);
+		tokenizer.readColumns(columns);
+		assertTrue(columns.size() == 3);
+		assertEquals(" one partridge ", columns.get(0));
+		assertEquals("  two turtle doves  ", columns.get(1));
+		assertEquals("   three french hens   ", columns.get(2));
+		assertEquals(input, tokenizer.getUntokenizedRow());
+		
+		// same input when surrounding spaces require quotes
+		tokenizer = createTokenizer(input, SPACES_NEED_QUOTES_PREFERENCE);
+		tokenizer.readColumns(columns);
+		assertTrue(columns.size() == 3);
+		assertEquals("one partridge", columns.get(0));
+		assertEquals("two turtle doves", columns.get(1));
+		assertEquals("three french hens", columns.get(2));
+		assertEquals(input, tokenizer.getUntokenizedRow());
+	}
+	
+	/**
+	 * Tests that the CommentStartsWith comment matcher works (comments are skipped).
+	 */
+	@Test
+	public void testSkipCommentsStartsWith() throws IOException {
+		
+		final CsvPreference commentsStartWithPrefs = new CsvPreference.Builder(EXCEL_PREFERENCE).skipComments(
+			new CommentStartsWith("#")).build();
+		
+		final String input = "#comment\nnot,a,comment\n# another comment\nalso,not,comment";
+		final AbstractTokenizer tokenizer = createTokenizer(input, commentsStartWithPrefs);
+		tokenizer.readColumns(columns);
+		assertTrue(columns.size() == 3);
+		assertEquals("not", columns.get(0));
+		assertEquals("a", columns.get(1));
+		assertEquals("comment", columns.get(2));
+		
+		tokenizer.readColumns(columns);
+		assertTrue(columns.size() == 3);
+		assertEquals("also", columns.get(0));
+		assertEquals("not", columns.get(1));
+		assertEquals("comment", columns.get(2));
+		
+		assertFalse(tokenizer.readColumns(columns));
+	}
+	
+	/**
+	 * Tests that the CommentMatches comment matcher works (comments are skipped).
+	 */
+	@Test
+	public void testSkipCommentsMatches() throws IOException {
+		
+		final CsvPreference commentsMatchesPrefs = new CsvPreference.Builder(EXCEL_PREFERENCE).skipComments(
+			new CommentMatches("<!--.*-->")).build();
+		
+		final String input = "<!--comment-->\nnot,a,comment\n<!-- another comment-->\nalso,not,comment";
+		final AbstractTokenizer tokenizer = createTokenizer(input, commentsMatchesPrefs);
+		tokenizer.readColumns(columns);
+		assertTrue(columns.size() == 3);
+		assertEquals("not", columns.get(0));
+		assertEquals("a", columns.get(1));
+		assertEquals("comment", columns.get(2));
+		
+		tokenizer.readColumns(columns);
+		assertTrue(columns.size() == 3);
+		assertEquals("also", columns.get(0));
+		assertEquals("not", columns.get(1));
+		assertEquals("comment", columns.get(2));
+		
+		assertFalse(tokenizer.readColumns(columns));
+		
+	}
+	
+	/**
+	 * Tests that the readColumns() method reads a null column as null when preferences is ParseEmptyColumnsAsNull.
+	 */
+	@Test
+	public void testReadNullWithParseEmptyColumnsAsNull() throws Exception {
+		
+		final String input = ",";
+		tokenizer = createTokenizer(input, NORMAL_PREFERENCE);
+		assertTrue(NORMAL_PREFERENCE.getEmptyColumnParsing().equals(EmptyColumnParsing.ParseEmptyColumnsAsNull));
+		
+		tokenizer.readColumns(columns);
+		assertTrue(columns.size() == 2);
+		assertEquals(",", tokenizer.getUntokenizedRow());
+		assertEquals(null, columns.get(0));
+		assertEquals(null, columns.get(1));
+	}
+	
+
+	/**
+	 * Tests that the readColumns() method reads an empty string column as null when preferences is ParseEmptyColumnsAsNull.
+	 */
+	@Test
+	public void testReadEmptyStringsWithParseEmptyColumnsAsNull() throws Exception {
+		
+		final String input = "\"\",\"\"";
+		tokenizer = createTokenizer(input, NORMAL_PREFERENCE);
+		assertTrue(NORMAL_PREFERENCE.getEmptyColumnParsing().equals(EmptyColumnParsing.ParseEmptyColumnsAsNull));
+		
+		tokenizer.readColumns(columns);
+		assertTrue(columns.size() == 2);
+		assertEquals("\"\",\"\"", tokenizer.getUntokenizedRow());
+		assertEquals(null, columns.get(0));
+		assertEquals(null, columns.get(1));
+	}
+	
+	/**
+	 * Tests that the readColumns() method reads a null column as null when preferences is ParseEmptyColumnsAsEmptyString.
+	 */
+	@Test
+	public void testReadNullWithParseEmptyColumnsAsEmptyString() throws Exception {
+		
+		final String input = ",";
+		tokenizer = createTokenizer(input, PARSE_EMPTY_COLUMNS_AS_EMPTY_STRING_PREFERENCE);
+		assertTrue(PARSE_EMPTY_COLUMNS_AS_EMPTY_STRING_PREFERENCE.getEmptyColumnParsing().equals(EmptyColumnParsing.ParseEmptyColumnsAsEmptyString));
+		
+		tokenizer.readColumns(columns);
+		assertTrue(columns.size() == 2);
+		assertEquals(",", tokenizer.getUntokenizedRow());
+		assertEquals(null, columns.get(0));
+		assertEquals(null, columns.get(1));
+	}
+	
+	/**
+	 * Tests that the readColumns() method reads an empty string column as empty string when preferences is ParseEmptyColumnsAsEmptyString.
+	 */
+	@Test
+	public void testReadEmptyStringsWithParseEmptyColumnsAsEmptyString() throws Exception {
+		
+		final String input = "\"\",\"\"";
+		tokenizer = createTokenizer(input, PARSE_EMPTY_COLUMNS_AS_EMPTY_STRING_PREFERENCE);
+		assertTrue(PARSE_EMPTY_COLUMNS_AS_EMPTY_STRING_PREFERENCE.getEmptyColumnParsing().equals(EmptyColumnParsing.ParseEmptyColumnsAsEmptyString));
+		
+		tokenizer.readColumns(columns);
+		assertTrue(columns.size() == 2);
+		assertEquals("\"\",\"\"", tokenizer.getUntokenizedRow());
+		assertEquals("", columns.get(0));
+		assertEquals("", columns.get(1));
+	}	
+	
+}


### PR DESCRIPTION
Fix to https://github.com/super-csv/super-csv/issues/77
Editing Tokenizer.java will work, but that would break the existing flow.
Hence I provided the separate tokenizer that can be used in case if we need strict parsing.