### PR TITLE
Added ParseEmptyColumnAndNullAsEmptyString option to preference emptyColumnParsing.

### DIFF
--- a/super-csv/src/main/java/org/supercsv/io/EmptyColumnParsing.java
+++ b/super-csv/src/main/java/org/supercsv/io/EmptyColumnParsing.java
@@ -17,8 +17,11 @@ package org.supercsv.io;
 
 /**
  * @author Pietro Aragona
+ * @author Yoshiyuki Takemori
  * @since 2.4.1
  */
 public enum EmptyColumnParsing {
-	ParseEmptyColumnsAsNull, ParseEmptyColumnsAsEmptyString
+	ParseEmptyColumnsAsNull,
+	ParseEmptyColumnsAsEmptyString,
+	ParseEmptyColumnsAndNullAsEmptyString
 }

--- a/super-csv/src/main/java/org/supercsv/io/Tokenizer.java
+++ b/super-csv/src/main/java/org/supercsv/io/Tokenizer.java
@@ -31,6 +31,7 @@ import org.supercsv.prefs.CsvPreference;
  * @author Kasper B. Graversen
  * @author James Bassett
  * @author Pietro Aragona
+ * @author Yoshiyuki Takemori
  */
 public class Tokenizer extends AbstractTokenizer {
 	

--- a/super-csv/src/main/java/org/supercsv/io/Tokenizer.java
+++ b/super-csv/src/main/java/org/supercsv/io/Tokenizer.java
@@ -316,6 +316,9 @@ public class Tokenizer extends AbstractTokenizer {
 		if(currentColumn.length() > 0){
 			columns.add(currentColumn.toString());
 		}
+		else if( emptyColumnParsing.equals(EmptyColumnParsing.ParseEmptyColumnsAndNullAsEmptyString) ) {
+			columns.add("");
+		}
 		else{
 			int previousCharIndex = charIndex - 1;
 			boolean availableCharacters = previousCharIndex >= 0 ;

--- a/super-csv/src/test/java/org/supercsv/io/TokenizerTest.java
+++ b/super-csv/src/test/java/org/supercsv/io/TokenizerTest.java
@@ -45,7 +45,7 @@ public class TokenizerTest {
 		.ignoreEmptyLines(false).build();
 	private static final CsvPreference PARSE_EMPTY_COLUMNS_AS_EMPTY_STRING_PREFERENCE = new CsvPreference.Builder(EXCEL_PREFERENCE)
 		.setEmptyColumnParsing(EmptyColumnParsing.ParseEmptyColumnsAsEmptyString).build();
-	private static final CsvPreference PARSE_EMPTY_COLUMNS_AS_EMPTY_STRING_ALL_PREFERENCE = new CsvPreference.Builder(EXCEL_PREFERENCE)
+	private static final CsvPreference PARSE_EMPTY_COLUMNS_AND_NULL_AS_EMPTY_STRING_PREFERENCE = new CsvPreference.Builder(EXCEL_PREFERENCE)
 		.setEmptyColumnParsing(EmptyColumnParsing.ParseEmptyColumnsAndNullAsEmptyString).build();
 		
 	private Tokenizer tokenizer;
@@ -790,14 +790,14 @@ public class TokenizerTest {
 	}	
 	
 	/**
-	 * Tests that the readColumns() method reads an null column as empty string when preferences is ParseEmptyColumnsAsEmptyStringAll.
+	 * Tests that the readColumns() method reads an null column as empty string when preferences is ParseEmptyColumnsAndNullAsEmptyString.
 	 */
 	@Test
 	public void testReadNullWithParseEmptyColumnsAndNullAsEmptyString() throws Exception {
 		
 		final String input = ",";
-		tokenizer = createTokenizer(input, PARSE_EMPTY_COLUMNS_AS_EMPTY_STRING_ALL_PREFERENCE);
-		assertTrue(PARSE_EMPTY_COLUMNS_AS_EMPTY_STRING_ALL_PREFERENCE.getEmptyColumnParsing().equals(EmptyColumnParsing.ParseEmptyColumnsAndNullAsEmptyString));
+		tokenizer = createTokenizer(input, PARSE_EMPTY_COLUMNS_AND_NULL_AS_EMPTY_STRING_PREFERENCE);
+		assertTrue(PARSE_EMPTY_COLUMNS_AND_NULL_AS_EMPTY_STRING_PREFERENCE.getEmptyColumnParsing().equals(EmptyColumnParsing.ParseEmptyColumnsAndNullAsEmptyString));
 		
 		tokenizer.readColumns(columns);
 		assertTrue(columns.size() == 2);
@@ -807,14 +807,14 @@ public class TokenizerTest {
 	}	
 
 	/**
-	 * Tests that the readColumns() method reads an empty string column as empty string when preferences is ParseEmptyColumnsAsEmptyStringAll.
+	 * Tests that the readColumns() method reads an empty string column as empty string when preferences is ParseEmptyColumnsAndNullAsEmptyString.
 	 */
 	@Test
 	public void testReadEmptyStringWithParseEmptyColumnsAndNullAsEmptyString() throws Exception {
 		
 		final String input = "\"\",\"\"";
-		tokenizer = createTokenizer(input, PARSE_EMPTY_COLUMNS_AS_EMPTY_STRING_ALL_PREFERENCE);
-		assertTrue(PARSE_EMPTY_COLUMNS_AS_EMPTY_STRING_ALL_PREFERENCE.getEmptyColumnParsing().equals(EmptyColumnParsing.ParseEmptyColumnsAndNullAsEmptyString));
+		tokenizer = createTokenizer(input, PARSE_EMPTY_COLUMNS_AND_NULL_AS_EMPTY_STRING_PREFERENCE);
+		assertTrue(PARSE_EMPTY_COLUMNS_AND_NULL_AS_EMPTY_STRING_PREFERENCE.getEmptyColumnParsing().equals(EmptyColumnParsing.ParseEmptyColumnsAndNullAsEmptyString));
 		
 		tokenizer.readColumns(columns);
 		assertTrue(columns.size() == 2);

--- a/super-csv/src/test/java/org/supercsv/io/TokenizerTest.java
+++ b/super-csv/src/test/java/org/supercsv/io/TokenizerTest.java
@@ -45,6 +45,8 @@ public class TokenizerTest {
 		.ignoreEmptyLines(false).build();
 	private static final CsvPreference PARSE_EMPTY_COLUMNS_AS_EMPTY_STRING_PREFERENCE = new CsvPreference.Builder(EXCEL_PREFERENCE)
 		.setEmptyColumnParsing(EmptyColumnParsing.ParseEmptyColumnsAsEmptyString).build();
+	private static final CsvPreference PARSE_EMPTY_COLUMNS_AS_EMPTY_STRING_ALL_PREFERENCE = new CsvPreference.Builder(EXCEL_PREFERENCE)
+		.setEmptyColumnParsing(EmptyColumnParsing.ParseEmptyColumnsAndNullAsEmptyString).build();
 		
 	private Tokenizer tokenizer;
 	private List<String> columns;
@@ -787,4 +789,37 @@ public class TokenizerTest {
 		assertEquals("", columns.get(1));
 	}	
 	
+	/**
+	 * Tests that the readColumns() method reads an null column as empty string when preferences is ParseEmptyColumnsAsEmptyStringAll.
+	 */
+	@Test
+	public void testReadNullWithParseEmptyColumnsAndNullAsEmptyString() throws Exception {
+		
+		final String input = ",";
+		tokenizer = createTokenizer(input, PARSE_EMPTY_COLUMNS_AS_EMPTY_STRING_ALL_PREFERENCE);
+		assertTrue(PARSE_EMPTY_COLUMNS_AS_EMPTY_STRING_ALL_PREFERENCE.getEmptyColumnParsing().equals(EmptyColumnParsing.ParseEmptyColumnsAndNullAsEmptyString));
+		
+		tokenizer.readColumns(columns);
+		assertTrue(columns.size() == 2);
+		assertEquals(",", tokenizer.getUntokenizedRow());
+		assertEquals("", columns.get(0));
+		assertEquals("", columns.get(1));
+	}	
+
+	/**
+	 * Tests that the readColumns() method reads an empty string column as empty string when preferences is ParseEmptyColumnsAsEmptyStringAll.
+	 */
+	@Test
+	public void testReadEmptyStringWithParseEmptyColumnsAndNullAsEmptyString() throws Exception {
+		
+		final String input = "\"\",\"\"";
+		tokenizer = createTokenizer(input, PARSE_EMPTY_COLUMNS_AS_EMPTY_STRING_ALL_PREFERENCE);
+		assertTrue(PARSE_EMPTY_COLUMNS_AS_EMPTY_STRING_ALL_PREFERENCE.getEmptyColumnParsing().equals(EmptyColumnParsing.ParseEmptyColumnsAndNullAsEmptyString));
+		
+		tokenizer.readColumns(columns);
+		assertTrue(columns.size() == 2);
+		assertEquals("\"\",\"\"", tokenizer.getUntokenizedRow());
+		assertEquals("", columns.get(0));
+		assertEquals("", columns.get(1));
+	}	
 }


### PR DESCRIPTION
Hello. I like super-csv very much.

I often want to process an empty column (with or without quotes) as an empty string for safe coding against null.

Therefore, I made this change.

I wanted to fix the manual, but my English ability was difficult. I'm sorry.
If this change is accepted, somebody would like to fix the manual.