### PR TITLE
Add Split and Merge CellProcessors for List reading and writing 

### DIFF
--- a/super-csv/src/main/java/org/supercsv/cellprocessor/Merge.java
+++ b/super-csv/src/main/java/org/supercsv/cellprocessor/Merge.java
@@ -1,15 +1,49 @@
+/*
+ * Copyright 2007 Kasper B. Graversen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.supercsv.cellprocessor;
 
 import org.supercsv.cellprocessor.ift.StringCellProcessor;
 import org.supercsv.util.CsvContext;
 
+/**
+ * Merges multiple adjacent cells into one cell. Only use with {@code CsvListReader} or {@code CsvListWriter}.
+ *
+ * @author Jamie Baggott
+ */
 public class Merge extends CellProcessorAdaptor implements StringCellProcessor {
     private String separator;
 
+    /**
+     * Creates new {@code Merge} instance, using a blank {@code String} as separator.
+     */
+    public Merge() {
+        this("");
+    }
+
+    /**
+     * Creates new {@code Merge} instance, using a given separator as separator.
+     * @param separator String to use as separator
+     */
     public Merge(String separator) {
         this.separator = separator;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public Object execute(final Object value, final CsvContext context) {
         validateInputNotNull(value, context);
         return next.execute(value + separator, context);

--- a/super-csv/src/main/java/org/supercsv/cellprocessor/Merge.java
+++ b/super-csv/src/main/java/org/supercsv/cellprocessor/Merge.java
@@ -1,0 +1,17 @@
+package org.supercsv.cellprocessor;
+
+import org.supercsv.cellprocessor.ift.StringCellProcessor;
+import org.supercsv.util.CsvContext;
+
+public class Merge extends CellProcessorAdaptor implements StringCellProcessor {
+    private String separator;
+
+    public Merge(String separator) {
+        this.separator = separator;
+    }
+
+    public Object execute(final Object value, final CsvContext context) {
+        validateInputNotNull(value, context);
+        return next.execute(value + separator, context);
+    }
+}

--- a/super-csv/src/main/java/org/supercsv/cellprocessor/Split.java
+++ b/super-csv/src/main/java/org/supercsv/cellprocessor/Split.java
@@ -1,0 +1,30 @@
+package org.supercsv.cellprocessor;
+
+import org.supercsv.cellprocessor.ift.StringCellProcessor;
+import org.supercsv.util.CsvContext;
+
+public class Split extends CellProcessorAdaptor implements StringCellProcessor {
+    private String delimiter;
+    private int times;
+
+    public Split(String delimiter) {
+        this(delimiter, -1);
+    }
+
+    public Split(String delimiter, int times) {
+        this.delimiter = delimiter;
+        this.times = times;
+    }
+
+    public Object execute(final Object value, final CsvContext context) {
+        validateInputNotNull(value, context);
+
+        String[] cellArray;
+        if (times == -1)
+            cellArray = ((String) value).split(delimiter);
+        else
+            cellArray = ((String) value).split(delimiter, times);
+
+        return next.execute(cellArray, context);
+    }
+}

--- a/super-csv/src/main/java/org/supercsv/cellprocessor/Split.java
+++ b/super-csv/src/main/java/org/supercsv/cellprocessor/Split.java
@@ -3,27 +3,47 @@ package org.supercsv.cellprocessor;
 import org.supercsv.cellprocessor.ift.StringCellProcessor;
 import org.supercsv.util.CsvContext;
 
+/**
+ * Splits a single cell into multiple cells. The cell is split on the given delimiter, and the number of resulting
+ * parts comes from the given parts. Only use with {@code CsvListReader} or {@code CsvListWriter}.
+ *
+ * @author Jamie Baggott
+ */
 public class Split extends CellProcessorAdaptor implements StringCellProcessor {
     private String delimiter;
-    private int times;
+    private int parts;
 
+    /**
+     * Creates new {@code Split} instance, using the given delimiter to split on and setting parts to 0. When parts is
+     * 0, there is no limit on the amount of parts this processor produces.
+     * @param delimiter String to split cell on
+     */
     public Split(String delimiter) {
-        this(delimiter, -1);
+        this(delimiter, 0);
     }
 
-    public Split(String delimiter, int times) {
+    /**
+     * Creates new {@code Split} instance, using the given delimiter to split the cell on, and the given parts as the
+     * amount of parts to return.
+     * @param delimiter String to split cell on
+     * @param parts Parts to divide cell into
+     */
+    public Split(String delimiter, int parts) {
         this.delimiter = delimiter;
-        this.times = times;
+        this.parts = parts;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public Object execute(final Object value, final CsvContext context) {
         validateInputNotNull(value, context);
 
         String[] cellArray;
-        if (times == -1)
+        if (parts == 0)
             cellArray = ((String) value).split(delimiter);
         else
-            cellArray = ((String) value).split(delimiter, times);
+            cellArray = ((String) value).split(delimiter, parts);
 
         return next.execute(cellArray, context);
     }

--- a/super-csv/src/main/java/org/supercsv/util/Util.java
+++ b/super-csv/src/main/java/org/supercsv/util/Util.java
@@ -16,9 +16,11 @@
 package org.supercsv.util;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
+import org.supercsv.cellprocessor.Merge;
 import org.supercsv.cellprocessor.ift.CellProcessor;
 import org.supercsv.exception.SuperCsvConstraintViolationException;
 import org.supercsv.exception.SuperCsvException;
@@ -82,15 +84,27 @@ public final class Util {
 		}
 		
 		destination.clear();
-		
+
+		Object value;
+		StringBuilder mergeBuilder;
 		for( int i = 0; i < source.size(); i++ ) {
 			
 			context.setColumnNumber(i + 1); // update context (columns start at 1)
 			
 			if( processors[i] == null ) {
 				destination.add(source.get(i)); // no processing required
+			} else if (processors[i] instanceof Merge) {
+				mergeBuilder = new StringBuilder();
+				for (;processors[i] instanceof Merge; i++) {
+					mergeBuilder.append(processors[i].execute(source.get(i), context));
+				}
+				i--;
+				destination.add(mergeBuilder.toString());
 			} else {
-				destination.add(processors[i].execute(source.get(i), context)); // execute the processor chain
+				if ((value = processors[i].execute(source.get(i), context)) instanceof Object[])
+					destination.addAll(Arrays.asList((Object[]) value));
+				else
+					destination.add(value); // execute the processor chain
 			}
 		}
 	}

--- a/super-csv/src/main/java/org/supercsv/util/Util.java
+++ b/super-csv/src/main/java/org/supercsv/util/Util.java
@@ -93,18 +93,18 @@ public final class Util {
 			
 			if( processors[i] == null ) {
 				destination.add(source.get(i)); // no processing required
-			} else if (processors[i] instanceof Merge) {
+			} else if (processors[i] instanceof Merge) { // Merges cells with adjacent Merge processors together
 				mergeBuilder = new StringBuilder();
-				for (;processors[i] instanceof Merge; i++) {
+				for (; i < processors.length && processors[i] instanceof Merge; i++) {
 					mergeBuilder.append(processors[i].execute(source.get(i), context));
 				}
-				i--;
+				if (i != processors.length) i--;
 				destination.add(mergeBuilder.toString());
 			} else {
-				if ((value = processors[i].execute(source.get(i), context)) instanceof Object[])
-					destination.addAll(Arrays.asList((Object[]) value));
+				if ((value = processors[i].execute(source.get(i), context)) instanceof Object[]) // execute the processor chain
+					destination.addAll(Arrays.asList((Object[]) value)); // If array, add values individually
 				else
-					destination.add(value); // execute the processor chain
+					destination.add(value); // If not array, just add value
 			}
 		}
 	}

--- a/super-csv/src/test/java/org/supercsv/features/ReadingFeaturesTest.java
+++ b/super-csv/src/test/java/org/supercsv/features/ReadingFeaturesTest.java
@@ -18,10 +18,7 @@ package org.supercsv.features;
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.supercsv.cellprocessor.ParseBigDecimal;
-import org.supercsv.cellprocessor.ParseDate;
-import org.supercsv.cellprocessor.ParseInt;
-import org.supercsv.cellprocessor.Trim;
+import org.supercsv.cellprocessor.*;
 import org.supercsv.cellprocessor.constraint.NotNull;
 import org.supercsv.cellprocessor.ift.CellProcessor;
 import org.supercsv.comment.CommentMatches;
@@ -355,16 +352,42 @@ public class ReadingFeaturesTest {
 	public void testDeepConversion() {
 		Assert.assertNotNull("See org.supercsv.example.dozer.Reading class!");
 	}
-	
-	@Ignore
+
 	@Test
-	public void testSplitCellToMultipleProperties() {
-		throw new UnsupportedOperationException("Not implemented yet!");
+	public void testSplitCellToMultipleProperties() throws Exception {
+		String csv = "My Full Name";
+		CellProcessor[] processors = { new Split(" ") };
+
+		CsvListReader listReader = new CsvListReader(new StringReader(csv), STANDARD_PREFERENCE);
+		List<Object> person = listReader.read(processors);
+		listReader.close();
+
+		Assert.assertArrayEquals(new Object[]{"My", "Full", "Name"}, person.toArray());
+
+		processors[0] = new Split(" ", 2);
+		listReader = new CsvListReader(new StringReader(csv), STANDARD_PREFERENCE);
+		person = listReader.read(processors);
+		listReader.close();
+
+		Assert.assertArrayEquals(new Object[]{"My", "Full Name"}, person.toArray());
 	}
-	
-	@Ignore
+
 	@Test
-	public void testJoinMultipleCellsIntoOneProperty() {
-		throw new UnsupportedOperationException("Not implemented yet!");
+	public void testJoinMultipleCellsIntoOneProperty() throws Exception {
+		String csv = "My,Full,Name";
+		CellProcessor[] processors = { new Merge(" "), new Merge(" "), new Merge() };
+
+		CsvListReader listReader = new CsvListReader(new StringReader(csv), STANDARD_PREFERENCE);
+		List<Object> person = listReader.read(processors);
+		listReader.close();
+
+		Assert.assertArrayEquals(new Object[]{"My Full Name"}, person.toArray());
+
+		processors = new CellProcessor[]{ new Merge(" "), new Merge(), null };
+		listReader = new CsvListReader(new StringReader(csv), STANDARD_PREFERENCE);
+		person = listReader.read(processors);
+		listReader.close();
+
+		Assert.assertArrayEquals(new Object[]{"My Full", "Name"}, person.toArray());
 	}
 }

--- a/super-csv/src/test/java/org/supercsv/features/WritingFeaturesTest.java
+++ b/super-csv/src/test/java/org/supercsv/features/WritingFeaturesTest.java
@@ -18,9 +18,7 @@ package org.supercsv.features;
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.supercsv.cellprocessor.FmtDate;
-import org.supercsv.cellprocessor.FmtNumber;
-import org.supercsv.cellprocessor.Trim;
+import org.supercsv.cellprocessor.*;
 import org.supercsv.cellprocessor.constraint.NotNull;
 import org.supercsv.cellprocessor.ift.CellProcessor;
 import org.supercsv.io.CsvBeanWriter;
@@ -34,10 +32,7 @@ import java.io.StringWriter;
 import java.math.BigDecimal;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
-import java.util.Arrays;
-import java.util.Calendar;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 
 import static org.supercsv.prefs.CsvPreference.STANDARD_PREFERENCE;
 
@@ -257,17 +252,51 @@ public class WritingFeaturesTest {
 	public void testDeepConversion() {
 		Assert.assertNotNull("See org.supercsv.example.dozer.Writing class!");
 	}
-	
-	@Ignore
+
 	@Test
-	public void testSplitCellToMultipleProperties() {
-		throw new UnsupportedOperationException("Not implemented yet!");
+	public void testSplitCellToMultipleProperties() throws Exception {
+		List<Object> csv = new ArrayList<Object>();
+		csv.add("My Full Name");
+		CellProcessor[] processors = { new Split(" ") };
+
+		StringWriter writer = new StringWriter();
+		CsvListWriter listWriter = new CsvListWriter(writer, STANDARD_PREFERENCE);
+		listWriter.write(csv, processors);
+		listWriter.close();
+
+		Assert.assertEquals("My,Full,Name\r\n", writer.toString());
+
+		processors[0] = new Split(" ", 2);
+		writer = new StringWriter();
+		listWriter = new CsvListWriter(writer, STANDARD_PREFERENCE);
+		listWriter.write(csv, processors);
+		listWriter.close();
+
+		Assert.assertEquals("My,Full Name\r\n", writer.toString());
 	}
-	
-	@Ignore
+
 	@Test
-	public void testJoinMultipleCellsIntoOneProperty() {
-		throw new UnsupportedOperationException("Not implemented yet!");
+	public void testJoinMultipleCellsIntoOneProperty() throws Exception {
+		List<Object> csv = new ArrayList<Object>();
+		csv.add("My");
+		csv.add("Full");
+		csv.add("Name");
+		CellProcessor[] processors = { new Merge(" "), new Merge(" "), new Merge() };
+
+		StringWriter writer = new StringWriter();
+		CsvListWriter listWriter = new CsvListWriter(writer, STANDARD_PREFERENCE);
+		listWriter.write(csv, processors);
+		listWriter.close();
+
+		Assert.assertEquals("My Full Name\r\n", writer.toString());
+
+		processors = new CellProcessor[] { new Merge(" "), new Merge(), null };
+		writer = new StringWriter();
+		listWriter = new CsvListWriter(writer, STANDARD_PREFERENCE);
+		listWriter.write(csv, processors);
+		listWriter.close();
+
+		Assert.assertEquals("My Full,Name\r\n", writer.toString());
 	}
 	
 	@Test


### PR DESCRIPTION
This pull request aims to start the process of adding Split and Merge CellProcessors, as referenced by issues #80 and #81 respectively. These added CellProcessors currently only work for `ListCsvReader` and `ListCsvWriter`. This is due to the fact that the other readers and writers will take slightly more work to implement, and I wondered whether anyone had any advice of how to better implement these features than how I have currently built them into the project.

To build these new features in the way that I have, I had to edit the `Util.executeCellProcessor` method, on top of just adding the new CellProcessors. This is because an array is returned from the Split CellProcessor, and the Merge CellProcessor requires accessing the adjacent cells and then continuing from the final merged one. Due to this non-conformist type of behaviour, these CellProcessors cannot easily, in their current form, have others chaining from them in a logical manner. As I said earlier, any advice on how I could make these implementations fit better with the project as a whole would be welcome and valuable.