### PR TITLE
Added Automatic-Module-Name to manifests through maven-jar-plugin

### DIFF
--- a/super-csv-dozer/pom.xml
+++ b/super-csv-dozer/pom.xml
@@ -77,6 +77,9 @@
 				<configuration>
 					<archive>
 						<manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+						<manifestEntries>
+							<Automatic-Module-Name>org.supercsv.io.dozer</Automatic-Module-Name>
+						</manifestEntries>
 					</archive>
 				</configuration>
 			</plugin>

--- a/super-csv-java8/pom.xml
+++ b/super-csv-java8/pom.xml
@@ -110,6 +110,9 @@
 				<configuration>
 					<archive>
 						<manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+						<manifestEntries>
+							<Automatic-Module-Name>org.supercsv.cellprocessor.time</Automatic-Module-Name>
+						</manifestEntries>
 					</archive>
 				</configuration>
 			</plugin>

--- a/super-csv-joda/pom.xml
+++ b/super-csv-joda/pom.xml
@@ -77,6 +77,9 @@
 				<configuration>
 					<archive>
 						<manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+						<manifestEntries>
+							<Automatic-Module-Name>org.supercsv.cellprocessor.joda</Automatic-Module-Name>
+						</manifestEntries>
 					</archive>
 				</configuration>
 			</plugin>

--- a/super-csv/pom.xml
+++ b/super-csv/pom.xml
@@ -77,6 +77,9 @@
 				<configuration>
 					<archive>
 						<manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+						<manifestEntries>
+							<Automatic-Module-Name>org.supercsv</Automatic-Module-Name>
+						</manifestEntries>
 					</archive>
 				</configuration>
 			</plugin>


### PR DESCRIPTION
See issue #138 

This pull request does not address the "org.supercsv.io" package conflict introduced by super-csv-java8.

The super-csv-java8 classes in that package should at least be moved to their own package and at best super-csv-java8 should be split into super-csv-java8-time and super-csv-java8-bean.