### PR TITLE
add CSV preference for writing a header

### DIFF
--- a/super-csv/src/main/java/org/supercsv/io/AbstractCsvWriter.java
+++ b/super-csv/src/main/java/org/supercsv/io/AbstractCsvWriter.java
@@ -126,6 +126,11 @@ public abstract class AbstractCsvWriter implements ICsvWriter {
 	public int getRowNumber() {
 		return rowNumber;
 	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public CsvPreference getPreference() { return preference; }
 	
 	/**
 	 * Writes a List of columns as a line to the CsvWriter.
@@ -225,8 +230,9 @@ public abstract class AbstractCsvWriter implements ICsvWriter {
 		
 		// update the current row/line numbers
 		incrementRowAndLineNo();
-		
-		writeRow(header);
+		if( preference.getWriteHeader() ) {
+			writeRow(header);
+		}
 	}
 	
 }

--- a/super-csv/src/main/java/org/supercsv/io/CsvResultSetWriter.java
+++ b/super-csv/src/main/java/org/supercsv/io/CsvResultSetWriter.java
@@ -59,8 +59,9 @@ public class CsvResultSetWriter extends AbstractCsvWriter implements ICsvResultS
 		if( resultSet == null ) {
 			throw new NullPointerException("ResultSet cannot be null");
 		}
-		
-		writeHeaders(resultSet); // increments row and line number
+		if ( getPreference().getWriteHeader() ) {
+			writeHeaders(resultSet); // increments row and line number
+		}
 		writeContents(resultSet); // increments row and line number before writing of each row
 	}
 	
@@ -74,8 +75,9 @@ public class CsvResultSetWriter extends AbstractCsvWriter implements ICsvResultS
 		if( writeProcessors == null ) {
 			throw new NullPointerException("CellProcessor[] cannot be null");
 		}
-		
-		writeHeaders(resultSet); // increments row and line number
+		if ( getPreference().getWriteHeader() ) {
+			writeHeaders(resultSet); // increments row and line number
+		}
 		writeContents(resultSet, writeProcessors); // increments row and line number before writing of each row
 	}
 	

--- a/super-csv/src/main/java/org/supercsv/io/ICsvWriter.java
+++ b/super-csv/src/main/java/org/supercsv/io/ICsvWriter.java
@@ -18,6 +18,7 @@ package org.supercsv.io;
 import java.io.Closeable;
 import java.io.Flushable;
 import java.io.IOException;
+import org.supercsv.prefs.CsvPreference;
 
 /**
  * The interface for CSV writers.
@@ -44,6 +45,14 @@ public interface ICsvWriter extends Closeable, Flushable {
 	 * @since 2.0.0
 	 */
 	int getRowNumber();
+
+	/**
+	 * Gets the CSV preferences object that the writer is set to use.
+	 *
+	 * @return the CSV preferences for the writer
+	 * @since 2.5.0
+	 */
+	CsvPreference getPreference();
 	
 	/**
 	 * Writes a single-line comment to the CSV file (the comment must already include any special comment characters

--- a/super-csv/src/main/java/org/supercsv/prefs/CsvPreference.java
+++ b/super-csv/src/main/java/org/supercsv/prefs/CsvPreference.java
@@ -145,6 +145,8 @@ public final class CsvPreference {
 	private final EmptyColumnParsing emptyColumnParsing;
 
 	private final char quoteEscapeChar;
+
+	private final boolean writeHeader;
 	
 	/**
 	 * Constructs a new <tt>CsvPreference</tt> from a Builder.
@@ -161,6 +163,7 @@ public final class CsvPreference {
 		this.maxLinesPerRow = builder.maxLinesPerRow;
 		this.emptyColumnParsing = builder.emptyColumnParsing;
 		this.quoteEscapeChar = builder.quoteEscapeChar;
+		this.writeHeader = builder.writeHeader;
 	}
 	
 	/**
@@ -265,6 +268,16 @@ public final class CsvPreference {
 	}
 
 	/**
+	 * Returns if the header should be written to the CSV file. The CsvResultSetWriter class uses this
+	 * variable to determine if it should automatically write the header to the output CSV file.
+	 *
+	 * @return true if the header should be written to the CSV file.
+	 */
+	public boolean getWriteHeader() {
+		return writeHeader;
+	}
+
+	/**
 	 * Builds immutable <tt>CsvPreference</tt> instances. The builder pattern allows for additional preferences to be
 	 * added in the future.
 	 */
@@ -291,6 +304,8 @@ public final class CsvPreference {
 		private EmptyColumnParsing emptyColumnParsing;
 
 		private char quoteEscapeChar;
+
+		private boolean writeHeader = true;
 		
 		/**
 		 * Constructs a Builder with all of the values from an existing <tt>CsvPreference</tt> instance. Useful if you
@@ -477,6 +492,19 @@ public final class CsvPreference {
 		 */
 		public Builder setQuoteEscapeChar(final char quoteEscapeChar) {
 			this.quoteEscapeChar = quoteEscapeChar;
+			return this;
+		}
+
+		/**
+		 * Value indicating if headers should be written to the CSV file by a class implementing ICsvWriter.
+		 * The default value is true.
+		 *
+		 * @since 2.5.0
+		 * @param writeHeader value indicating if the header should be written
+		 * @return the updated Builder
+		 */
+		public Builder setWriteHeader(final boolean writeHeader) {
+			this.writeHeader = writeHeader;
 			return this;
 		}
 		

--- a/super-csv/src/test/java/org/supercsv/SuperCsvTestUtils.java
+++ b/super-csv/src/test/java/org/supercsv/SuperCsvTestUtils.java
@@ -148,6 +148,14 @@ public class SuperCsvTestUtils {
 		.append(BOB_CSV).append("\r\n").append(ALICE_CSV).append("\r\n").append(BILL_CSV).append("\r\n")
 		.append(MIRANDA_CSV).append("\r\n").append(STEVE_CSV).append("\r\n").append(ADA_CSV).append("\r\n")
 		.append(SERGEI_CSV).append("\r\n").append(LARRY_CSV).append("\r\n").append(GRACE_CSV).append("\r\n").toString();
+
+	/**
+	 * The CSV file to use for testing.
+	 */
+	public static final String CSV_FILE_WITHOUT_HEADERS = new StringBuilder(JOHN_CSV).append("\r\n")
+			.append(BOB_CSV).append("\r\n").append(ALICE_CSV).append("\r\n").append(BILL_CSV).append("\r\n")
+			.append(MIRANDA_CSV).append("\r\n").append(STEVE_CSV).append("\r\n").append(ADA_CSV).append("\r\n")
+			.append(SERGEI_CSV).append("\r\n").append(LARRY_CSV).append("\r\n").append(GRACE_CSV).append("\r\n").toString();
 		
 	/** List of populated customer beans to use for testing */
 	public static final List<CustomerBean> CUSTOMERS = Arrays.asList(JOHN, BOB, ALICE, BILL, MIRANDA, STEVE, ADA,

--- a/super-csv/src/test/java/org/supercsv/io/CsvResultSetWriterTest.java
+++ b/super-csv/src/test/java/org/supercsv/io/CsvResultSetWriterTest.java
@@ -18,6 +18,7 @@ package org.supercsv.io;
 
 import static org.junit.Assert.*;
 import static org.supercsv.SuperCsvTestUtils.CSV_FILE;
+import static org.supercsv.SuperCsvTestUtils.CSV_FILE_WITHOUT_HEADERS;
 import static org.supercsv.SuperCsvTestUtils.HEADER;
 import static org.supercsv.SuperCsvTestUtils.CUSTOMERS;
 import static org.supercsv.SuperCsvTestUtils.STRING_CUSTOMERS;
@@ -116,6 +117,21 @@ public class CsvResultSetWriterTest {
 		csvResultSetWriter.write(resultSetMock);
 		csvResultSetWriter.flush();
 		assertEquals(CSV_FILE, writer.toString());
+	}
+
+	/**
+	 * Tests writing ResultSet to a CSV file with the writeHeaders flag set to false (no CellProcessors)
+	 *
+	 * @throws SQLException
+	 */
+	@Test
+	public void testWriteWithoutHeaders() throws IOException, SQLException {
+		final CsvPreference withoutHeadersPreference = new CsvPreference.Builder(CsvPreference.STANDARD_PREFERENCE).setWriteHeader(false).build();
+		csvResultSetWriter = new CsvResultSetWriter(writer, withoutHeadersPreference);
+		final ResultSet resultSetMock = new ResultSetMock(TEST_DATA_STRINGS, HEADER);
+		csvResultSetWriter.write(resultSetMock);
+		csvResultSetWriter.flush();
+		assertEquals(CSV_FILE_WITHOUT_HEADERS, writer.toString());
 	}
 	
 	/**


### PR DESCRIPTION
see #149 

not sure if this is the best way to do it or not since I'm not sure if this preference affects writers other than CsvResultSetWriter , and I also had to expose the encapsulated CsvPreference object to access it within CsvResultSetWriter to determine whether or not to write the header

let me know what you think and I can change things, thank you for taking the time to review!