### PR TITLE
Fix old partialWriteWithCsvDozerBeanWriter() is to an example of partial writing

### DIFF
--- a/super-csv-dozer/src/test/java/org/supercsv/example/dozer/Writing.java
+++ b/super-csv-dozer/src/test/java/org/supercsv/example/dozer/Writing.java
@@ -113,7 +113,7 @@ public class Writing {
 				"answers[2].questionNo",
 				"answers[2].answer" };
 		
-		// ignore questionNo/answer 1 columns keep uo with partialFieldMapping
+		// ignore questionNo/answer 1 columns keep up with partialFieldMapping
 		final CellProcessor[] partialProcessors = new CellProcessor[] { 
 			new Token(0, "age not supplied"), // age
 			new FmtBool("Y", "N"),                 // consent

--- a/super-csv-dozer/src/test/java/org/supercsv/example/dozer/Writing.java
+++ b/super-csv-dozer/src/test/java/org/supercsv/example/dozer/Writing.java
@@ -104,13 +104,19 @@ public class Writing {
 	 * An example of partial reading using CsvDozerBeanWriter.
 	 */
 	private static void partialWriteWithCsvDozerBeanWriter() throws Exception {
+		// ignore questionNo/answer 1 columns
+		final String[] partialFieldMapping = new String[] {
+				"age",
+				"consentGiven",
+				"answers[1].questionNo",
+				"answers[1].answer",
+				"answers[2].questionNo",
+				"answers[2].answer" };
 		
-		// null ages and answers are converted to something more meaningful
+		// ignore questionNo/answer 1 columns keep uo with partialFieldMapping
 		final CellProcessor[] partialProcessors = new CellProcessor[] { 
 			new Token(0, "age not supplied"), // age
 			new FmtBool("Y", "N"),                 // consent
-			new NotNull(),                         // questionNo 1
-			new ConvertNullTo("not answered"),     // answer 1
 			new NotNull(),                         // questionNo 2
 			new ConvertNullTo("not answered"),     // answer 2
 			new NotNull(),                         // questionNo 3
@@ -131,10 +137,10 @@ public class Writing {
 				CsvPreference.STANDARD_PREFERENCE);
 			
 			// configure the mapping from the fields to the CSV columns
-			beanWriter.configureBeanMapping(SurveyResponse.class, FIELD_MAPPING);
+			beanWriter.configureBeanMapping(SurveyResponse.class, partialFieldMapping);
 			
 			// write the header
-			beanWriter.writeHeader("age", "consentGiven", "questionNo1", "answer1", "questionNo2", "answer2",
+			beanWriter.writeHeader("age", "consentGiven", "questionNo2", "answer2",
 				"questionNo3", "answer3");
 			
 			// write the beans


### PR DESCRIPTION
The old ```partialWriteWithCsvDozerBeanWriter()``` is not an example of partial writing. I modify it to make it a right example.