### PR TITLE
Fix double quote within double quote should fail validation

### DIFF
--- a/src/site/apt/preferences.apt
+++ b/src/site/apt/preferences.apt
@@ -69,6 +69,10 @@ CSV Preferences
 
     []
 
+    [strictQuote] whether verify that the double-quotes conforms to that If double-quotes are used to enclose fields, then a double-quote appearing inside a field must be escaped by preceding it with another escape char. The default value is false (not verify).
+
+    []
+
 * Predefined preferences
 
   There are four 'ready to use' configurations for typical scenarios.
@@ -102,6 +106,8 @@ CSV Preferences
  quoteMode                   | {{{./apidocs/org/supercsv/quote/NormalQuoteMode.html}NormalQuoteMode}}
 *----------------------------+-------------------------------------------------------------------------------------*
  skipComments                | false (no CommentMatcher used)
+*----------------------------+-------------------------------------------------------------------------------------*
+ strictQuote                 | false
 *----------------------------+-------------------------------------------------------------------------------------*
 
 * Create your own preference
@@ -227,3 +233,14 @@ private static final CsvPreference CUSTOM_ENCODER =
 private static final CsvPreference STANDARD_SKIP_COMMENTS = 
     new CsvPreference.Builder(CsvPreference.STANDARD_PREFERENCE).skipComments(new CommentStartsWith("#").build();
 +------------------------------------------------------------------------------------------------------------------------------------------------+
+
+* verify strict quote
+
+  By default, it doesn't verify that the double-quotes conforms to that If double-quotes are used to enclose fields,
+  then a double-quote appearing inside a field must be escaped by preceding it with another escape char. If you'd like to
+  verify, you can enable this behaviour by calling <<<strictQuote(true)>>> on the Builder
+
++-------------------------------------------------------------------------------------------------------------------------------------------------+
+private static final CsvPreference ALLOW_EMPTY_LINES =
+    new CsvPreference.Builder(CsvPreference.STANDARD_PREFERENCE).strictQuote(true).build();
++-------------------------------------------------------------------------------------------------------------------------------------------------+

--- a/super-csv/src/main/java/org/supercsv/prefs/CsvPreference.java
+++ b/super-csv/src/main/java/org/supercsv/prefs/CsvPreference.java
@@ -149,6 +149,8 @@ public final class CsvPreference {
 	private final EmptyColumnParsing emptyColumnParsing;
 
 	private final char quoteEscapeChar;
+
+	private final boolean strictQuote;
 	
 	/**
 	 * Constructs a new <tt>CsvPreference</tt> from a Builder.
@@ -165,6 +167,7 @@ public final class CsvPreference {
 		this.maxLinesPerRow = builder.maxLinesPerRow;
 		this.emptyColumnParsing = builder.emptyColumnParsing;
 		this.quoteEscapeChar = builder.quoteEscapeChar;
+		this.strictQuote = builder.strictQuote;
 	}
 	
 	/**
@@ -269,6 +272,15 @@ public final class CsvPreference {
 	}
 
 	/**
+	 * Returns the strictQuote flag.
+	 *
+	 * @return the strictQuote flag
+	 */
+	public boolean isStrictQuote() {
+		return strictQuote;
+	}
+
+	/**
 	 * Builds immutable <tt>CsvPreference</tt> instances. The builder pattern allows for additional preferences to be
 	 * added in the future.
 	 */
@@ -295,6 +307,8 @@ public final class CsvPreference {
 		private EmptyColumnParsing emptyColumnParsing;
 
 		private char quoteEscapeChar;
+
+		private boolean strictQuote = false;
 		
 		/**
 		 * Constructs a Builder with all of the values from an existing <tt>CsvPreference</tt> instance. Useful if you
@@ -315,6 +329,7 @@ public final class CsvPreference {
 			this.maxLinesPerRow = preference.maxLinesPerRow;
 			this.emptyColumnParsing = preference.emptyColumnParsing;
 			this.quoteEscapeChar = preference.quoteEscapeChar;
+			this.strictQuote = preference.strictQuote;
 		}
 		
 		/**
@@ -481,6 +496,20 @@ public final class CsvPreference {
 		 */
 		public Builder setQuoteEscapeChar(final char quoteEscapeChar) {
 			this.quoteEscapeChar = quoteEscapeChar;
+			return this;
+		}
+		
+		/** Flag indicating whether verify that the double-quotes conforms to that If double-quotes are used to enclose
+		 * fields, then a double-quote appearing inside a field must be escaped by preceding it with another escape char.
+		 * The default is <tt>false</tt>
+		 *
+		 * @since 2.5.0
+		 * @param strictQuote
+		 *          Flag indicating whether verify that the double-quotes
+		 * @return
+		 */
+		public Builder strictQuote(final boolean strictQuote) {
+			this.strictQuote = strictQuote;
 			return this;
 		}
 		

--- a/super-csv/src/test/java/org/supercsv/prefs/CsvPreferenceTest.java
+++ b/super-csv/src/test/java/org/supercsv/prefs/CsvPreferenceTest.java
@@ -73,6 +73,7 @@ public class CsvPreferenceTest {
 		assertTrue(custom.getEncoder() instanceof DefaultCsvEncoder);
 		assertTrue(custom.getQuoteMode() instanceof NormalQuoteMode);
 		assertEquals('"', custom.getQuoteEscapeChar());
+		assertFalse(custom.isStrictQuote());
 	}
 	
 	/**
@@ -85,6 +86,7 @@ public class CsvPreferenceTest {
 				.useEncoder(new DefaultCsvEncoder())
 				.useQuoteMode(new AlwaysQuoteMode())
 				.setQuoteEscapeChar('\\')
+				.strictQuote(true)
 				.build();
 		assertEquals('"', custom.getQuoteChar());
 		assertEquals(',', custom.getDelimiterChar());
@@ -93,6 +95,7 @@ public class CsvPreferenceTest {
 		assertTrue(custom.getEncoder() instanceof DefaultCsvEncoder);
 		assertTrue(custom.getQuoteMode() instanceof AlwaysQuoteMode);
 		assertEquals('\\', custom.getQuoteEscapeChar());
+		assertTrue(custom.isStrictQuote());
 	}
 	
 	/**
@@ -108,6 +111,7 @@ public class CsvPreferenceTest {
 		assertEquals(EXCEL_PREFERENCE.getEncoder(), custom.getEncoder());
 		assertEquals(EXCEL_PREFERENCE.getQuoteMode(), custom.getQuoteMode());
 		assertEquals(EXCEL_PREFERENCE.getQuoteEscapeChar(), custom.getQuoteEscapeChar());
+		assertEquals(EXCEL_PREFERENCE.isStrictQuote(), custom.isStrictQuote());
 	}
 	
 	/**
@@ -124,6 +128,7 @@ public class CsvPreferenceTest {
 		assertTrue(custom.getEncoder() instanceof DefaultCsvEncoder);
 		assertTrue(custom.getQuoteMode() instanceof AlwaysQuoteMode);
 		assertEquals(EXCEL_PREFERENCE.getQuoteEscapeChar(), custom.getQuoteEscapeChar());
+		assertEquals(EXCEL_PREFERENCE.isStrictQuote(), custom.isStrictQuote());
 	}
 	
 	/**


### PR DESCRIPTION
Hi, @kbilsted 
This PR put ```strictQuote``` configuration flags in the ```CsvPreference``` class to verify that If double-quotes are used to enclose fields, then a double-quote appearing inside a field must be escaped by preceding it with another double quote (RFC 4180 section 2.7).
fix #151 
fix #77 