### PR TITLE
-Super csv 116

### DIFF
--- a/src/site/apt/preferences.apt
+++ b/src/site/apt/preferences.apt
@@ -44,6 +44,10 @@ CSV Preferences
 
     []
 
+    [ignoreEmptyColumnsLines] Whether lines only containing column delimiters are ignored. The default value is false (null values would be returned for all columns).
+
+    []
+
     [emptyColumnParsing] Controls how to handle empty columns, whether they should be treated as null, or as an empty String: "".  Valid values are ParseEmptyColumnsAsNull and ParseEmptyColumnsAsEmptyString.  The default value is ParseEmptyColumnsAsNull.
 
     []
@@ -94,6 +98,8 @@ CSV Preferences
  surroundingSpacesNeedQuotes | false
 *----------------------------+-------------------------------------------------------------------------------------*
  ignoreEmptyLines            | true
+*----------------------------+-------------------------------------------------------------------------------------*
+ ignoreEmptyColumnsLines     | false
 *----------------------------+-------------------------------------------------------------------------------------*
  maxLinesPerRow              | 0 (disabled)
 *----------------------------+-------------------------------------------------------------------------------------*
@@ -146,6 +152,16 @@ private static final CsvPreference STANDARD_SURROUNDING_SPACES_NEED_QUOTES =
 +----------------------------------------------------------------------------------------------------+
 private static final CsvPreference ALLOW_EMPTY_LINES =
     new CsvPreference.Builder(CsvPreference.STANDARD_PREFERENCE).ignoreEmptyLines(false).build();
++----------------------------------------------------------------------------------------------------+
+
+* Ignoring rows containing only empty columns
+
+  By default, if a line contains only column delimiters, the line is treated as a record of empty columns. You can set the behavior to skip such
+  lines, similar to ignoring empty lines, by setting the <<<ignoreEmptyColumnsLines>>> preference:
+
++----------------------------------------------------------------------------------------------------+
+private static final CsvPreference SKIP_EMPTY_COLUMN_LINES =
+    new CsvPreference.Builder(CsvPreference.STANDARD_PREFERENCE).ignoreEmptyColumnsLines(true).build();
 +----------------------------------------------------------------------------------------------------+
 
 * Handling empty columns

--- a/super-csv/src/main/java/org/supercsv/io/Tokenizer.java
+++ b/super-csv/src/main/java/org/supercsv/io/Tokenizer.java
@@ -22,6 +22,7 @@ import java.util.List;
 import org.supercsv.comment.CommentMatcher;
 import org.supercsv.exception.SuperCsvException;
 import org.supercsv.prefs.CsvPreference;
+import org.supercsv.prefs.EmptyColumnsStrategy;
 
 /**
  * Reads the CSV file, line by line. If you want the line-reading functionality of this class, but want to define your
@@ -31,6 +32,7 @@ import org.supercsv.prefs.CsvPreference;
  * @author Kasper B. Graversen
  * @author James Bassett
  * @author Pietro Aragona
+ * @author Kai Hackemesser
  */
 public class Tokenizer extends AbstractTokenizer {
 	
@@ -58,7 +60,9 @@ public class Tokenizer extends AbstractTokenizer {
 	private final EmptyColumnParsing emptyColumnParsing;
 
 	private final char quoteEscapeChar;
-	
+
+	protected EmptyColumnsStrategy emptyFieldStrategy;
+
 	/**
 	 * Enumeration of tokenizer states. QUOTE_MODE is activated between quotes.
 	 */
@@ -86,6 +90,7 @@ public class Tokenizer extends AbstractTokenizer {
 		this.maxLinesPerRow = preferences.getMaxLinesPerRow();
 		this.emptyColumnParsing = preferences.getEmptyColumnParsing();
 		this.quoteEscapeChar = preferences.getQuoteEscapeChar();
+		this.emptyFieldStrategy = preferences.getEmptyColumnsStrategy();
 	}
 	
 	/**
@@ -110,7 +115,8 @@ public class Tokenizer extends AbstractTokenizer {
 				return false; // EOF
 			}
 		}
-		while( ignoreEmptyLines && line.length() == 0 || (commentMatcher != null && commentMatcher.isComment(line)) );
+		while( ignoreEmptyLines && line.length() == 0 || (commentMatcher != null && commentMatcher.isComment(line))
+				|| emptyFieldStrategy.toBeSkipped(line, (char) delimiterChar));
 		
 		// update the untokenized CSV row
 		currentRow.append(line);

--- a/super-csv/src/main/java/org/supercsv/prefs/CsvPreference.java
+++ b/super-csv/src/main/java/org/supercsv/prefs/CsvPreference.java
@@ -105,6 +105,7 @@ import org.supercsv.quote.QuoteMode;
  * @author Kasper B. Graversen
  * @author James Bassett
  * @author Pietro Aragona
+ * @author Kai Hackemesser
  */
 public final class CsvPreference {
 	
@@ -143,7 +144,9 @@ public final class CsvPreference {
 	private final QuoteMode quoteMode;
 	
 	private final CommentMatcher commentMatcher;
-	
+
+	private final EmptyColumnsStrategy emptyColumnsStrategy;
+
 	private int maxLinesPerRow = 0;
 	
 	private final EmptyColumnParsing emptyColumnParsing;
@@ -165,6 +168,7 @@ public final class CsvPreference {
 		this.maxLinesPerRow = builder.maxLinesPerRow;
 		this.emptyColumnParsing = builder.emptyColumnParsing;
 		this.quoteEscapeChar = builder.quoteEscapeChar;
+		this.emptyColumnsStrategy = builder.emptyColumnsStrategy;
 	}
 	
 	/**
@@ -269,6 +273,15 @@ public final class CsvPreference {
 	}
 
 	/**
+	 * @return the strategy to handle rows with all empty fields, i.e. only delimiters.
+	 * By default, such rows will be processed. To change this behavior, use the
+	 * {@link Builder#ignoreEmptyColumnsLines(boolean)} method.
+	 */
+	public EmptyColumnsStrategy getEmptyColumnsStrategy() {
+		return emptyColumnsStrategy;
+	}
+
+	/**
 	 * Builds immutable <tt>CsvPreference</tt> instances. The builder pattern allows for additional preferences to be
 	 * added in the future.
 	 */
@@ -295,7 +308,9 @@ public final class CsvPreference {
 		private EmptyColumnParsing emptyColumnParsing;
 
 		private char quoteEscapeChar;
-		
+
+		private EmptyColumnsStrategy emptyColumnsStrategy = EmptyColumnsStrategy.PASS;
+
 		/**
 		 * Constructs a Builder with all of the values from an existing <tt>CsvPreference</tt> instance. Useful if you
 		 * want to base your preferences off one of the existing CsvPreference constants.
@@ -513,7 +528,17 @@ public final class CsvPreference {
 			
 			return new CsvPreference(this);
 		}
-		
+
+		/**
+		 * Configures the behavior in regards to lines only containing column delimiters. By default, a row of empty
+		 * columns is returned
+		 * @param ignore if set to true, lines containing only column delimiters will be skipped.
+		 * @return the builder.
+		 */
+		public Builder ignoreEmptyColumnsLines(boolean ignore) {
+			this.emptyColumnsStrategy = ignore? EmptyColumnsStrategy.FILTER : EmptyColumnsStrategy.PASS;
+			return this;
+		}
 	}
 	
 }

--- a/super-csv/src/main/java/org/supercsv/prefs/EmptyColumnsStrategy.java
+++ b/super-csv/src/main/java/org/supercsv/prefs/EmptyColumnsStrategy.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.supercsv.prefs;
+
+/**
+ * The strategies that the Tokenizer can use about interpreting rows with all fields of a row empty (i.e. a row of
+ * commas only)
+ *
+ * @author Kai Hackemesser
+ */
+public enum EmptyColumnsStrategy {
+
+    /**
+     * Lines with only empty columns are to be skipped.
+     */
+   FILTER {
+        public boolean toBeSkipped(String line, char delimiter) {
+            return line.matches("^("+ delimiter+")+$");
+        }
+    },
+    /**
+     * Lines with only empty columns are to be returned.
+     */
+    PASS ;
+
+    /**
+     *  analyzes the row.
+     * @return true if the Tokenizer should skip this row during processing.
+     */
+    public boolean toBeSkipped(String line, char delimiter) {
+        return false;
+    }
+}

--- a/super-csv/src/test/java/org/supercsv/io/TokenizerTest.java
+++ b/super-csv/src/test/java/org/supercsv/io/TokenizerTest.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.junit.After;
@@ -146,7 +147,44 @@ public class TokenizerTest {
 		assertEquals(3, tokenizer.getLineNumber());
 		assertEquals("this is the third line", tokenizer.getUntokenizedRow());
 	}
-	
+
+	/**
+	 * Tests that the readColumns() method does not skip over lines with only commas by default
+	 */
+	@Test
+	public void testEmptyFieldsOnlyLinesDefaultBehaviour() throws Exception {
+		final String input = "a,b,c,d\r\n,,,,\r\ne,f,g,h\r\n";;
+		final List<String> expectedColumnsRow1 = Arrays.asList("a","b","c", "d");
+		final List<String> expectedColumnsRow2 = Arrays.asList(null, null, null, null, null);
+		final List<String> expectedColumnsRow3 = Arrays.asList("e","f","g", "h");
+		tokenizer = createTokenizer(input, EXCEL_PREFERENCE);
+		tokenizer.readColumns(columns);
+		assertEquals(expectedColumnsRow1, columns);
+		tokenizer.readColumns(columns);
+		assertEquals(expectedColumnsRow2, columns);
+		tokenizer.readColumns(columns);
+		assertEquals(expectedColumnsRow3, columns);
+	}
+
+	/**
+	 * Tests that the readColumns() method does skip over lines with only commas by default, when the preferences are
+	 * set accordingly
+	 */
+	@Test
+	public void testEmptyFieldsOnlyLinesBehaviourSkipping() throws Exception {
+		final String input = "a,b,c,d\r\n,,,,\r\ne,f,g,h\r\n";;
+		final List<String> expectedColumnsRow1 = Arrays.asList("a","b","c", "d");
+		final List<String> expectedColumnsRow3 = Arrays.asList("e","f","g", "h");
+		CsvPreference preference = new CsvPreference.Builder(EXCEL_PREFERENCE).ignoreEmptyColumnsLines(true).build();
+		tokenizer = createTokenizer(input, preference);
+		tokenizer.readColumns(columns);
+		assertEquals(expectedColumnsRow1, columns);
+		tokenizer.readColumns(columns);
+		assertEquals(expectedColumnsRow3, columns);
+		assertEquals(3, tokenizer.getLineNumber());
+	}
+
+
 	/**
 	 * Tests that the readColumns() method doesn't skip over empty lines if the ignoreEmptyLines
 	 * preference is disabled.


### PR DESCRIPTION
This is an implementation of issue #116 .

To make use of this feature, the user must use the preferences builder and set call ```ignoreEmptyFieldLines(true)```  on it.
