### PR TITLE
Fix JavaDoc to support HTML5

### DIFF
--- a/super-csv-dozer/src/main/java/org/supercsv/io/dozer/CsvDozerBeanReader.java
+++ b/super-csv-dozer/src/main/java/org/supercsv/io/dozer/CsvDozerBeanReader.java
@@ -46,8 +46,8 @@ public class CsvDozerBeanReader extends AbstractCsvReader implements ICsvDozerBe
 	private final CsvDozerBeanData beanData = new CsvDozerBeanData();
 	
 	/**
-	 * Constructs a new <tt>CsvDozerBeanReader</tt> with the supplied Reader and CSV preferences and creates it's own
-	 * DozerBeanMapper. Note that the <tt>reader</tt> will be wrapped in a <tt>BufferedReader</tt> before accessed.
+	 * Constructs a new <code>CsvDozerBeanReader</code> with the supplied Reader and CSV preferences and creates it's own
+	 * DozerBeanMapper. Note that the <code>reader</code> will be wrapped in a <code>BufferedReader</code> before accessed.
 	 * 
 	 * @param reader
 	 *            the reader
@@ -62,7 +62,7 @@ public class CsvDozerBeanReader extends AbstractCsvReader implements ICsvDozerBe
 	}
 	
 	/**
-	 * Constructs a new <tt>CsvDozerBeanReader</tt> with the supplied (custom) Tokenizer and CSV preferences and creates
+	 * Constructs a new <code>CsvDozerBeanReader</code> with the supplied (custom) Tokenizer and CSV preferences and creates
 	 * it's own DozerBeanMapper. The tokenizer should be set up with the Reader (CSV input) and CsvPreference
 	 * beforehand.
 	 * 
@@ -79,8 +79,8 @@ public class CsvDozerBeanReader extends AbstractCsvReader implements ICsvDozerBe
 	}
 	
 	/**
-	 * Constructs a new <tt>CsvDozerBeanReader</tt> with the supplied Reader, CSV preferences and DozerBeanMapper. Note
-	 * that the <tt>reader</tt> will be wrapped in a <tt>BufferedReader</tt> before accessed.
+	 * Constructs a new <code>CsvDozerBeanReader</code> with the supplied Reader, CSV preferences and DozerBeanMapper. Note
+	 * that the <code>reader</code> will be wrapped in a <code>BufferedReader</code> before accessed.
 	 * 
 	 * @param reader
 	 *            the reader
@@ -101,7 +101,7 @@ public class CsvDozerBeanReader extends AbstractCsvReader implements ICsvDozerBe
 	}
 	
 	/**
-	 * Constructs a new <tt>CsvDozerBeanReader</tt> with the supplied (custom) Tokenizer, CSV preferences and
+	 * Constructs a new <code>CsvDozerBeanReader</code> with the supplied (custom) Tokenizer, CSV preferences and
 	 * DozerBeanMapper. The tokenizer should be set up with the Reader (CSV input) and CsvPreference beforehand.
 	 * 
 	 * @param tokenizer
@@ -240,7 +240,7 @@ public class CsvDozerBeanReader extends AbstractCsvReader implements ICsvDozerBe
 		 * @param clazz
 		 *            the class to add mapping configuration for (same as the type passed into write methods)
 		 * @param fieldMapping
-		 *            the field mapping for for each column (may contain <tt>null</tt> elements to indicate ignored
+		 *            the field mapping for for each column (may contain <code>null</code> elements to indicate ignored
 		 *            columns)
 		 * @throws NullPointerException
 		 *             if clazz or fieldMapping is null
@@ -262,7 +262,7 @@ public class CsvDozerBeanReader extends AbstractCsvReader implements ICsvDozerBe
 		 * @param clazz
 		 *            the class to add mapping configuration for (same as the type passed into write methods)
 		 * @param fieldMapping
-		 *            the field mapping for for each column (may contain <tt>null</tt> elements to indicate ignored
+		 *            the field mapping for for each column (may contain <code>null</code> elements to indicate ignored
 		 *            columns)
 		 * @throws NullPointerException
 		 *             if clazz, fieldMapping or hintTypes is null

--- a/super-csv-dozer/src/main/java/org/supercsv/io/dozer/CsvDozerBeanWriter.java
+++ b/super-csv-dozer/src/main/java/org/supercsv/io/dozer/CsvDozerBeanWriter.java
@@ -50,8 +50,8 @@ public class CsvDozerBeanWriter extends AbstractCsvWriter implements ICsvDozerBe
 	private final List<Object> processedColumns = new ArrayList<Object>();
 	
 	/**
-	 * Constructs a new <tt>CsvDozerBeanWriter</tt> with the supplied Writer and CSV preferences and and creates it's
-	 * own DozerBeanMapper. Note that the <tt>writer</tt> will be wrapped in a <tt>BufferedWriter</tt> before accessed.
+	 * Constructs a new <code>CsvDozerBeanWriter</code> with the supplied Writer and CSV preferences and and creates it's
+	 * own DozerBeanMapper. Note that the <code>writer</code> will be wrapped in a <code>BufferedWriter</code> before accessed.
 	 * 
 	 * @param writer
 	 *            the writer
@@ -66,8 +66,8 @@ public class CsvDozerBeanWriter extends AbstractCsvWriter implements ICsvDozerBe
 	}
 	
 	/**
-	 * Constructs a new <tt>CsvDozerBeanWriter</tt> with the supplied Writer, CSV preferences and DozerBeanMapper. Note
-	 * that the <tt>writer</tt> will be wrapped in a <tt>BufferedWriter</tt> before accessed.
+	 * Constructs a new <code>CsvDozerBeanWriter</code> with the supplied Writer, CSV preferences and DozerBeanMapper. Note
+	 * that the <code>writer</code> will be wrapped in a <code>BufferedWriter</code> before accessed.
 	 * 
 	 * @param writer
 	 *            the writer
@@ -152,7 +152,7 @@ public class CsvDozerBeanWriter extends AbstractCsvWriter implements ICsvDozerBe
 		 * @param clazz
 		 *            the class to add mapping configuration for (same as the type passed into write methods)
 		 * @param fieldMapping
-		 *            the field mapping for for each column (cannot contain <tt>null</tt> elements)
+		 *            the field mapping for for each column (cannot contain <code>null</code> elements)
 		 * @throws NullPointerException
 		 *             if clazz or fieldMapping (or one of its elements) is null
 		 */

--- a/super-csv-dozer/src/main/java/org/supercsv/io/dozer/ICsvDozerBeanReader.java
+++ b/super-csv-dozer/src/main/java/org/supercsv/io/dozer/ICsvDozerBeanReader.java
@@ -39,8 +39,8 @@ public interface ICsvDozerBeanReader extends ICsvReader {
 	 * <p>
 	 * Each element of the fieldMapping array represents a CSV column to be read and uses the standard Dozer field
 	 * mapping syntax. For example, if you were configuring the mappings for Person class you might define
-	 * <tt>firstName</tt> as the first element (just a simple field mapping), <tt>address.city</tt> as the second
-	 * element (a nested - or deep - field mapping), and <tt>accounts[0].balance</tt> as the third element (index based
+	 * <code>firstName</code> as the first element (just a simple field mapping), <code>address.city</code> as the second
+	 * element (a nested - or deep - field mapping), and <code>accounts[0].balance</code> as the third element (index based
 	 * mapping).
 	 * <p>
 	 * If you require access to the other features of Dozer in your mappings (customer getters/setters, bean factories,
@@ -49,7 +49,7 @@ public interface ICsvDozerBeanReader extends ICsvReader {
 	 * @param clazz
 	 *            the class to add mapping configuration for (same as the type passed into write methods)
 	 * @param fieldMapping
-	 *            the field mapping for for each column (may contain <tt>null</tt> elements to indicate ignored columns)
+	 *            the field mapping for for each column (may contain <code>null</code> elements to indicate ignored columns)
 	 * @throws NullPointerException
 	 *             if clazz or fieldMapping is null
 	 * @since 2.0.0
@@ -65,12 +65,12 @@ public interface ICsvDozerBeanReader extends ICsvReader {
 	 * <p>
 	 * Each element of the fieldMapping array represents a CSV column to be read and uses the standard Dozer field
 	 * mapping syntax. For example, if you were configuring the mappings for Person class you might define
-	 * <tt>firstName</tt> as the first element (just a simple field mapping), <tt>address.city</tt> as the second
-	 * element (a nested - or deep - field mapping), and <tt>accounts[0].balance</tt> as the third element (index based
+	 * <code>firstName</code> as the first element (just a simple field mapping), <code>address.city</code> as the second
+	 * element (a nested - or deep - field mapping), and <code>accounts[0].balance</code> as the third element (index based
 	 * mapping).
 	 * <p>
-	 * If you are mapping to an indexed list element (e.g. <tt>accounts[0]</tt>) and using a cell processor to return a
-	 * custom bean type (e.g. a <tt>ParseAccount</tt> processor that creates an <tt>Account</tt> bean), you will need to
+	 * If you are mapping to an indexed list element (e.g. <code>accounts[0]</code>) and using a cell processor to return a
+	 * custom bean type (e.g. a <code>ParseAccount</code> processor that creates an <code>Account</code> bean), you will need to
 	 * specify a hint for that column so Dozer can map that column.
 	 * <p>
 	 * If you require access to the other features of Dozer in your mappings (customer getters/setters, bean factories,
@@ -79,10 +79,10 @@ public interface ICsvDozerBeanReader extends ICsvReader {
 	 * @param clazz
 	 *            the class to add mapping configuration for (same as the type passed into write methods)
 	 * @param fieldMapping
-	 *            the field mapping for for each column (may contain <tt>null</tt> elements to indicate ignored columns)
+	 *            the field mapping for for each column (may contain <code>null</code> elements to indicate ignored columns)
 	 * @param hintTypes
 	 *            an array of types used as hints for Dozer when mapping to an indexed list element (e.g.
-	 *            <tt>accounts[0]</tt>) - a null element indicates no hint is required for that column
+	 *            <code>accounts[0]</code>) - a null element indicates no hint is required for that column
 	 * @throws NullPointerException
 	 *             if clazz, fieldMapping, or hintTypes is null
 	 * @throws IllegalArgumentException
@@ -136,7 +136,7 @@ public interface ICsvDozerBeanReader extends ICsvReader {
 	/**
 	 * Reads a row of a CSV file and populates an instance of the specified class, using Dozer to map column values to
 	 * the appropriate fields. Before population the data can be further processed by cell processors (each element in
-	 * the processors array corresponds with a CSV column). A <tt>null</tt> entry in the processors array indicates no
+	 * the processors array corresponds with a CSV column). A <code>null</code> entry in the processors array indicates no
 	 * further processing is required (the unprocessed String value will be set on the bean's field) - though Dozer will
 	 * attempt some conversions of it's own it the types don't match.
 	 * 
@@ -162,7 +162,7 @@ public interface ICsvDozerBeanReader extends ICsvReader {
 	/**
 	 * Reads a row of a CSV file and populates the supplied bean, using Dozer to map column values to the appropriate
 	 * fields. Before population the data can be further processed by cell processors (each element in the processors
-	 * array corresponds with a CSV column). A <tt>null</tt> entry in the processors array indicates no further
+	 * array corresponds with a CSV column). A <code>null</code> entry in the processors array indicates no further
 	 * processing is required (the unprocessed String value will be set on the bean's field) - though Dozer will attempt
 	 * some conversions of it's own it the types don't match.
 	 * 

--- a/super-csv-dozer/src/main/java/org/supercsv/io/dozer/ICsvDozerBeanWriter.java
+++ b/super-csv-dozer/src/main/java/org/supercsv/io/dozer/ICsvDozerBeanWriter.java
@@ -40,9 +40,9 @@ public interface ICsvDozerBeanWriter extends ICsvWriter {
 	 * <p>
 	 * Each element of the fieldMapping array represents a CSV column to be written and uses the standard Dozer field
 	 * mapping syntax. For example, if you were configuring the mappings for Person class you might define
-	 * <tt>firstName</tt> as the first element (just a simple field mapping), <tt>address.city</tt> as the second
+	 * <code>firstName</code> as the first element (just a simple field mapping), <code>address.city</code> as the second
 	 * element (a nested - or deep - field mapping), and
-	 * <tt>accounts[0].balance</tt> as the third element (index based mapping).
+	 * <code>accounts[0].balance</code> as the third element (index based mapping).
 	 * <p>
 	 * If you require access to the other features of Dozer in your mappings (customer getters/setters, bean factories, custom converters), 
 	 * then you should supply your own DozerBeanMapper to the Writer instead.
@@ -50,7 +50,7 @@ public interface ICsvDozerBeanWriter extends ICsvWriter {
 	 * @param clazz
 	 *            the class to add mapping configuration for (same as the type passed into write methods)
 	 * @param fieldMapping
-	 *            the field mapping for for each column (cannot contain <tt>null</tt> elements)
+	 *            the field mapping for for each column (cannot contain <code>null</code> elements)
 	 * @throws NullPointerException
 	 *             if clazz or fieldMapping (or one of its elements) is null
 	 * @since 2.0.0
@@ -59,7 +59,7 @@ public interface ICsvDozerBeanWriter extends ICsvWriter {
 	
 	/**
 	 * Writes the fields of the object as columns of a CSV file, using the pre-configured DozerBeanMapper to map fields
-	 * to the appropriate columns. <tt>toString()</tt> will be called on each element prior to writing.
+	 * to the appropriate columns. <code>toString()</code> will be called on each element prior to writing.
 	 * 
 	 * @param source
 	 *            the object (bean instance) containing the values to write
@@ -80,8 +80,8 @@ public interface ICsvDozerBeanWriter extends ICsvWriter {
 	 * to the appropriate columns.
 	 * <p>
 	 * Before writing, the data can be further processed by cell processors (each element in the processors array
-	 * corresponds with a CSV column). A <tt>null</tt> entry in the processors array indicates no further processing is
-	 * required (the value returned by toString() will be written as the column value). <tt>toString()</tt> will be
+	 * corresponds with a CSV column). A <code>null</code> entry in the processors array indicates no further processing is
+	 * required (the value returned by toString() will be written as the column value). <code>toString()</code> will be
 	 * called on each (processed) element prior to writing.
 	 * 
 	 * @param source
@@ -89,7 +89,7 @@ public interface ICsvDozerBeanWriter extends ICsvWriter {
 	 * @param processors
 	 *            an array of CellProcessors used to further process data before it is written (each element in the
 	 *            processors array corresponds with a CSV column - the number of processors should match the number of
-	 *            columns). A <tt>null</tt> entry indicates no further processing is required (the value returned by
+	 *            columns). A <code>null</code> entry indicates no further processing is required (the value returned by
 	 *            toString() will be written as the column value).
 	 * @throws IOException
 	 *             if an I/O error occurred

--- a/super-csv-java8/src/main/java/org/supercsv/cellprocessor/time/AbstractTemporalAccessorFormattingProcessor.java
+++ b/super-csv-java8/src/main/java/org/supercsv/cellprocessor/time/AbstractTemporalAccessorFormattingProcessor.java
@@ -37,7 +37,7 @@ public abstract class AbstractTemporalAccessorFormattingProcessor<T extends Temp
 	private final DateTimeFormatter formatter;
 
 	/**
-	 * Constructs a new <tt>AbstractTemporalAccessorFormattingProcessor</tt> processor,
+	 * Constructs a new <code>AbstractTemporalAccessorFormattingProcessor</code> processor,
 	 * which formats the type as a String.
 	 */
 	public AbstractTemporalAccessorFormattingProcessor() {
@@ -46,7 +46,7 @@ public abstract class AbstractTemporalAccessorFormattingProcessor<T extends Temp
 	}
 
 	/**
-	 * Constructs a new <tt>AbstractTemporalAccessorFormattingProcessor</tt> processor,
+	 * Constructs a new <code>AbstractTemporalAccessorFormattingProcessor</code> processor,
 	 * which formats the type as a String, then calls the next processor in
 	 * the chain.
 	 *
@@ -60,7 +60,7 @@ public abstract class AbstractTemporalAccessorFormattingProcessor<T extends Temp
 	}
 
 	/**
-	 * Constructs a new <tt>AbstractTemporalAccessorFormattingProcessor</tt> processor,
+	 * Constructs a new <code>AbstractTemporalAccessorFormattingProcessor</code> processor,
 	 * which formats the type as a String using the supplied formatter.
 	 *
 	 * @param formatter the formatter to use
@@ -72,7 +72,7 @@ public abstract class AbstractTemporalAccessorFormattingProcessor<T extends Temp
 	}
 
 	/**
-	 * Constructs a new <tt>AbstractTemporalAccessorFormattingProcessor</tt> processor,
+	 * Constructs a new <code>AbstractTemporalAccessorFormattingProcessor</code> processor,
 	 * which formats the type as a String using the supplied formatter,
 	 * then calls the next processor in the chain.
 	 *

--- a/super-csv-java8/src/main/java/org/supercsv/cellprocessor/time/AbstractTemporalAccessorParsingProcessor.java
+++ b/super-csv-java8/src/main/java/org/supercsv/cellprocessor/time/AbstractTemporalAccessorParsingProcessor.java
@@ -39,7 +39,7 @@ public abstract class AbstractTemporalAccessorParsingProcessor<T extends Tempora
 	private final DateTimeFormatter formatter;
 
 	/**
-	 * Constructs a new <tt>AbstractTemporalAccessorParsingProcessor</tt> processor, which
+	 * Constructs a new <code>AbstractTemporalAccessorParsingProcessor</code> processor, which
 	 * parses a String as a {@link TemporalAccessor} type.
 	 */
 	public AbstractTemporalAccessorParsingProcessor() {
@@ -47,7 +47,7 @@ public abstract class AbstractTemporalAccessorParsingProcessor<T extends Tempora
 	}
 
 	/**
-	 * Constructs a new <tt>AbstractTemporalAccessorParsingProcessor</tt> processor, which
+	 * Constructs a new <code>AbstractTemporalAccessorParsingProcessor</code> processor, which
 	 * parses a String as a {@link TemporalAccessor} type, then calls the next processor in the
 	 * chain.
 	 *
@@ -60,7 +60,7 @@ public abstract class AbstractTemporalAccessorParsingProcessor<T extends Tempora
 	}
 
 	/**
-	 * Constructs a new <tt>AbstractTemporalAccessorParsingProcessor</tt> processor, which
+	 * Constructs a new <code>AbstractTemporalAccessorParsingProcessor</code> processor, which
 	 * parses a String as a {@link TemporalAccessor} type using the supplied formatter.
 	 *
 	 * @param formatter the formatter used for parsing
@@ -72,7 +72,7 @@ public abstract class AbstractTemporalAccessorParsingProcessor<T extends Tempora
 	}
 
 	/**
-	 * Constructs a new <tt>AbstractTemporalAccessorParsingProcessor</tt> processor, which
+	 * Constructs a new <code>AbstractTemporalAccessorParsingProcessor</code> processor, which
 	 * parses a String as a {@link TemporalAccessor} type using the supplied formatter, then calls
 	 * the next processor in the chain.
 	 *

--- a/super-csv-java8/src/main/java/org/supercsv/cellprocessor/time/FmtDuration.java
+++ b/super-csv-java8/src/main/java/org/supercsv/cellprocessor/time/FmtDuration.java
@@ -34,7 +34,7 @@ import org.supercsv.util.CsvContext;
 public class FmtDuration extends CellProcessorAdaptor {
 
 	/**
-	 * Constructs a new <tt>FmtDuration</tt> processor, which formats a
+	 * Constructs a new <code>FmtDuration</code> processor, which formats a
 	 * Duration as a String in the ISO 8601 duration format,
 	 * in the same way as {@link Duration#toString()}
 	 *
@@ -44,7 +44,7 @@ public class FmtDuration extends CellProcessorAdaptor {
 	}
 
 	/**
-	 * Constructs a new <tt>FmtDuration</tt> processor, which formats a
+	 * Constructs a new <code>FmtDuration</code> processor, which formats a
 	 * Duration as a String, then calls the next processor in the chain.
 	 *
 	 * @param next next processor in the chain

--- a/super-csv-java8/src/main/java/org/supercsv/cellprocessor/time/FmtLocalDate.java
+++ b/super-csv-java8/src/main/java/org/supercsv/cellprocessor/time/FmtLocalDate.java
@@ -37,7 +37,7 @@ import org.supercsv.cellprocessor.ift.CellProcessor;
  */
 public class FmtLocalDate extends AbstractTemporalAccessorFormattingProcessor<LocalDate> {
 	/**
-	 * Constructs a new <tt>FmtLocalDate</tt> processor, which formats a
+	 * Constructs a new <code>FmtLocalDate</code> processor, which formats a
 	 * LocalDate as a String, with the same output as {@link LocalDate#toString()}
 	 */
 	public FmtLocalDate() {
@@ -45,7 +45,7 @@ public class FmtLocalDate extends AbstractTemporalAccessorFormattingProcessor<Lo
 	}
 
 	/**
-	 * Constructs a new <tt>FmtLocalDate</tt> processor, which formats a
+	 * Constructs a new <code>FmtLocalDate</code> processor, which formats a
 	 * LocalDate as a String, then calls the next processor in the chain.
 	 *
 	 * @param next next processor in the chain
@@ -57,7 +57,7 @@ public class FmtLocalDate extends AbstractTemporalAccessorFormattingProcessor<Lo
 	}
 
 	/**
-	 * Constructs a new <tt>FmtLocalDate</tt> processor, which formats a
+	 * Constructs a new <code>FmtLocalDate</code> processor, which formats a
 	 * LocalDate as a String using the supplied formatter.
 	 *
 	 * @param formatter the formatter to use
@@ -68,7 +68,7 @@ public class FmtLocalDate extends AbstractTemporalAccessorFormattingProcessor<Lo
 	}
 
 	/**
-	 * Constructs a new <tt>FmtLocalDate</tt> processor, which formats a
+	 * Constructs a new <code>FmtLocalDate</code> processor, which formats a
 	 * LocalDate as a String using the supplied formatter, then calls the next
 	 * processor in the chain.
 	 *

--- a/super-csv-java8/src/main/java/org/supercsv/cellprocessor/time/FmtLocalDateTime.java
+++ b/super-csv-java8/src/main/java/org/supercsv/cellprocessor/time/FmtLocalDateTime.java
@@ -38,7 +38,7 @@ import org.supercsv.cellprocessor.ift.CellProcessor;
 public class FmtLocalDateTime extends AbstractTemporalAccessorFormattingProcessor<LocalDateTime> {
 
 	/**
-	 * Constructs a new <tt>FmtLocalDateTime</tt> processor, which formats a
+	 * Constructs a new <code>FmtLocalDateTime</code> processor, which formats a
 	 * LocalDateTime as a String.
 	 *
 	 * The format is the same as obtained by {@link LocalDateTime#toString()}
@@ -48,7 +48,7 @@ public class FmtLocalDateTime extends AbstractTemporalAccessorFormattingProcesso
 	}
 
 	/**
-	 * Constructs a new <tt>FmtLocalDateTime</tt> processor, which formats a
+	 * Constructs a new <code>FmtLocalDateTime</code> processor, which formats a
 	 * LocalDateTime as a String, then calls the next processor in the
 	 * chain.
 	 *
@@ -60,7 +60,7 @@ public class FmtLocalDateTime extends AbstractTemporalAccessorFormattingProcesso
 	}
 
 	/**
-	 * Constructs a new <tt>FmtLocalDateTime</tt> processor, which formats a
+	 * Constructs a new <code>FmtLocalDateTime</code> processor, which formats a
 	 * LocalDateTime as a String using the supplied formatter.
 	 *
 	 * @param formatter the formatter to use
@@ -71,7 +71,7 @@ public class FmtLocalDateTime extends AbstractTemporalAccessorFormattingProcesso
 	}
 
 	/**
-	 * Constructs a new <tt>FmtLocalDateTime</tt> processor, which formats a
+	 * Constructs a new <code>FmtLocalDateTime</code> processor, which formats a
 	 * LocalDateTime as a String using the supplied formatter, then calls
 	 * the next processor in the chain.
 	 *

--- a/super-csv-java8/src/main/java/org/supercsv/cellprocessor/time/FmtLocalTime.java
+++ b/super-csv-java8/src/main/java/org/supercsv/cellprocessor/time/FmtLocalTime.java
@@ -37,7 +37,7 @@ import org.supercsv.cellprocessor.ift.CellProcessor;
  */
 public class FmtLocalTime extends AbstractTemporalAccessorFormattingProcessor<LocalTime> {
 	/**
-	 * Constructs a new <tt>FmtLocalTime</tt> processor, which formats a
+	 * Constructs a new <code>FmtLocalTime</code> processor, which formats a
 	 * LocalTime as a String.
 	 */
 	public FmtLocalTime() {
@@ -45,7 +45,7 @@ public class FmtLocalTime extends AbstractTemporalAccessorFormattingProcessor<Lo
 	}
 
 	/**
-	 * Constructs a new <tt>FmtLocalTime</tt> processor, which formats a
+	 * Constructs a new <code>FmtLocalTime</code> processor, which formats a
 	 * LocalTime as a String, then calls the next processor in the chain.
 	 *
 	 * @param next next processor in the chain
@@ -56,7 +56,7 @@ public class FmtLocalTime extends AbstractTemporalAccessorFormattingProcessor<Lo
 	}
 
 	/**
-	 * Constructs a new <tt>FmtLocalTime</tt> processor, which formats a
+	 * Constructs a new <code>FmtLocalTime</code> processor, which formats a
 	 * LocalTime as a String using the supplied formatter.
 	 *
 	 * @param formatter the formatter to use
@@ -67,7 +67,7 @@ public class FmtLocalTime extends AbstractTemporalAccessorFormattingProcessor<Lo
 	}
 
 	/**
-	 * Constructs a new <tt>FmtLocalTime</tt> processor, which formats a
+	 * Constructs a new <code>FmtLocalTime</code> processor, which formats a
 	 * LocalTime as a String using the supplied formatter, then calls the next
 	 * processor in the chain.
 	 *

--- a/super-csv-java8/src/main/java/org/supercsv/cellprocessor/time/FmtPeriod.java
+++ b/super-csv-java8/src/main/java/org/supercsv/cellprocessor/time/FmtPeriod.java
@@ -34,7 +34,7 @@ import org.supercsv.util.CsvContext;
 public class FmtPeriod extends CellProcessorAdaptor {
 
 	/**
-	 * Constructs a new <tt>FmtPeriod</tt> processor, which formats a
+	 * Constructs a new <code>FmtPeriod</code> processor, which formats a
 	 * Period as a String.
 	 */
 	public FmtPeriod() {
@@ -42,7 +42,7 @@ public class FmtPeriod extends CellProcessorAdaptor {
 	}
 
 	/**
-	 * Constructs a new <tt>FmtPeriod</tt> processor, which formats a
+	 * Constructs a new <code>FmtPeriod</code> processor, which formats a
 	 * Period as a String, then calls the next processor in the chain.
 	 *
 	 * @param next the next processor in the chain

--- a/super-csv-java8/src/main/java/org/supercsv/cellprocessor/time/FmtZoneId.java
+++ b/super-csv-java8/src/main/java/org/supercsv/cellprocessor/time/FmtZoneId.java
@@ -39,7 +39,7 @@ public class FmtZoneId extends CellProcessorAdaptor {
 	private final Locale locale;
 
 	/**
-	 * Constructs a new <tt>FmtZoneId</tt> processor, which formats a
+	 * Constructs a new <code>FmtZoneId</code> processor, which formats a
 	 * ZoneId as a String.
 	 */
 	public FmtZoneId() {
@@ -48,7 +48,7 @@ public class FmtZoneId extends CellProcessorAdaptor {
 	}
 
 	/**
-	 * Constructs a new <tt>FmtZoneId</tt> processor, which formats a
+	 * Constructs a new <code>FmtZoneId</code> processor, which formats a
 	 * ZoneId as a String, then calls the next processor in the chain.
 	 *
 	 * @param next next processor in the chain
@@ -61,7 +61,7 @@ public class FmtZoneId extends CellProcessorAdaptor {
 	}
 
 	/**
-	 * Constructs a new <tt>FmtZoneId</tt> processor, which formats a
+	 * Constructs a new <code>FmtZoneId</code> processor, which formats a
 	 * ZoneId as String, then calls the next processor in the chain.
 	 *
 	 * @param textStyle the TextStyle to use for formatting
@@ -76,7 +76,7 @@ public class FmtZoneId extends CellProcessorAdaptor {
 	}
 
 	/**
-	 * Constructs a new <tt>FmtZoneId</tt> processor, which formats a
+	 * Constructs a new <code>FmtZoneId</code> processor, which formats a
 	 * ZoneId as String, then calls the next processor in the chain.
 	 *
 	 * @param textStyle the TextStyle to use for formatting

--- a/super-csv-java8/src/main/java/org/supercsv/cellprocessor/time/FmtZonedDateTime.java
+++ b/super-csv-java8/src/main/java/org/supercsv/cellprocessor/time/FmtZonedDateTime.java
@@ -37,7 +37,7 @@ import org.supercsv.cellprocessor.ift.CellProcessor;
 public class FmtZonedDateTime extends AbstractTemporalAccessorFormattingProcessor<ZonedDateTime> {
 
 	/**
-	 * Constructs a new <tt>FmtZonedDateTime</tt> processor, which formats a
+	 * Constructs a new <code>FmtZonedDateTime</code> processor, which formats a
 	 * ZonedDateTime as a String.
 	 */
 	public FmtZonedDateTime() {
@@ -45,7 +45,7 @@ public class FmtZonedDateTime extends AbstractTemporalAccessorFormattingProcesso
 	}
 
 	/**
-	 * Constructs a new <tt>FmtZonedDateTime</tt> processor, which formats a
+	 * Constructs a new <code>FmtZonedDateTime</code> processor, which formats a
 	 * ZonedDateTime as a String, then calls the next processor in the chain.
 	 *
 	 * @param next next processor in the chain
@@ -56,7 +56,7 @@ public class FmtZonedDateTime extends AbstractTemporalAccessorFormattingProcesso
 	}
 
 	/**
-	 * Constructs a new <tt>FmtZonedDateTime</tt> processor, which formats a
+	 * Constructs a new <code>FmtZonedDateTime</code> processor, which formats a
 	 * ZonedDateTime as a String using the supplied formatter.
 	 *
 	 * @param formatter the formatter to use
@@ -67,7 +67,7 @@ public class FmtZonedDateTime extends AbstractTemporalAccessorFormattingProcesso
 	}
 
 	/**
-	 * Constructs a new <tt>FmtZonedDateTime</tt> processor, which formats a
+	 * Constructs a new <code>FmtZonedDateTime</code> processor, which formats a
 	 * ZonedDateTime as a String using the supplied formatter, then calls the next
 	 * processor in the chain.
 	 *

--- a/super-csv-java8/src/main/java/org/supercsv/cellprocessor/time/ParseDuration.java
+++ b/super-csv-java8/src/main/java/org/supercsv/cellprocessor/time/ParseDuration.java
@@ -37,14 +37,14 @@ import org.supercsv.util.CsvContext;
 public class ParseDuration extends CellProcessorAdaptor implements StringCellProcessor {
 
 	/**
-	 * Constructs a new <tt>ParseDuration</tt> processor, which parses a String
+	 * Constructs a new <code>ParseDuration</code> processor, which parses a String
 	 * as a Duration.
 	 */
 	public ParseDuration() {
 	}
 
 	/**
-	 * Constructs a new <tt>ParseDuration</tt> processor, which parses a String
+	 * Constructs a new <code>ParseDuration</code> processor, which parses a String
 	 * as a Duration, then calls the next processor in the chain.
 	 *
 	 * @param next the next processor in the chain

--- a/super-csv-java8/src/main/java/org/supercsv/cellprocessor/time/ParseLocalDate.java
+++ b/super-csv-java8/src/main/java/org/supercsv/cellprocessor/time/ParseLocalDate.java
@@ -29,7 +29,7 @@ import org.supercsv.cellprocessor.ift.CellProcessor;
 public class ParseLocalDate extends AbstractTemporalAccessorParsingProcessor<LocalDate> {
 
 	/**
-	 * Constructs a new <tt>ParseLocalDate</tt> processor,
+	 * Constructs a new <code>ParseLocalDate</code> processor,
 	 * which parses a String recognised by {@link LocalDate#parse(CharSequence)}
 	 * as a LocalDate.
 	 */
@@ -37,7 +37,7 @@ public class ParseLocalDate extends AbstractTemporalAccessorParsingProcessor<Loc
 	}
 
 	/**
-	 * Constructs a new <tt>ParseLocalDate</tt> processor,
+	 * Constructs a new <code>ParseLocalDate</code> processor,
 	 * which parses a String recognised by {@link LocalDate#parse(CharSequence)}
 	 * as a LocalDate, then calls the next processor in the chain.
 	 *
@@ -49,7 +49,7 @@ public class ParseLocalDate extends AbstractTemporalAccessorParsingProcessor<Loc
 	}
 
 	/**
-	 * Constructs a new <tt>ParseLocalDate</tt> processor, which parses a String
+	 * Constructs a new <code>ParseLocalDate</code> processor, which parses a String
 	 * as a LocalDate using the supplied formatter.
 	 *
 	 * @param formatter the formatter used for parsing
@@ -60,7 +60,7 @@ public class ParseLocalDate extends AbstractTemporalAccessorParsingProcessor<Loc
 	}
 
 	/**
-	 * Constructs a new <tt>ParseLocalDate</tt> processor, which parses a String
+	 * Constructs a new <code>ParseLocalDate</code> processor, which parses a String
 	 * as a LocalDate using the supplied formatter, then calls the next
 	 * processor in the chain.
 	 *

--- a/super-csv-java8/src/main/java/org/supercsv/cellprocessor/time/ParseLocalDateTime.java
+++ b/super-csv-java8/src/main/java/org/supercsv/cellprocessor/time/ParseLocalDateTime.java
@@ -38,14 +38,14 @@ import org.supercsv.cellprocessor.ift.CellProcessor;
 public class ParseLocalDateTime extends AbstractTemporalAccessorParsingProcessor<LocalDateTime> {
 
 	/**
-	 * Constructs a new <tt>ParseLocalDateTime</tt> processor, which parses a
+	 * Constructs a new <code>ParseLocalDateTime</code> processor, which parses a
 	 * String as a LocalDateTime, using {@link LocalDateTime#parse(CharSequence)}.
 	 */
 	public ParseLocalDateTime() {
 	}
 
 	/**
-	 * Constructs a new <tt>ParseLocalDateTime</tt> processor, which parses a
+	 * Constructs a new <code>ParseLocalDateTime</code> processor, which parses a
 	 * String as a LocalDateTime, then calls the next processor in the
 	 * chain.
 	 *
@@ -57,7 +57,7 @@ public class ParseLocalDateTime extends AbstractTemporalAccessorParsingProcessor
 	}
 
 	/**
-	 * Constructs a new <tt>ParseLocalDateTime</tt> processor, which parses a
+	 * Constructs a new <code>ParseLocalDateTime</code> processor, which parses a
 	 * String as a LocalDateTime using the supplied formatter.
 	 *
 	 * @param formatter the formatter used for parsing
@@ -68,7 +68,7 @@ public class ParseLocalDateTime extends AbstractTemporalAccessorParsingProcessor
 	}
 
 	/**
-	 * Constructs a new <tt>ParseLocalDateTime</tt> processor, which parses a
+	 * Constructs a new <code>ParseLocalDateTime</code> processor, which parses a
 	 * String as a LocalDateTime using the supplied formatter, then calls
 	 * the next processor in the chain.
 	 *

--- a/super-csv-java8/src/main/java/org/supercsv/cellprocessor/time/ParseLocalTime.java
+++ b/super-csv-java8/src/main/java/org/supercsv/cellprocessor/time/ParseLocalTime.java
@@ -38,7 +38,7 @@ import org.supercsv.cellprocessor.ift.CellProcessor;
 public class ParseLocalTime extends AbstractTemporalAccessorParsingProcessor<LocalTime> {
 
 	/**
-	 * Constructs a new <tt>ParseLocalTime</tt> processor, which parses a
+	 * Constructs a new <code>ParseLocalTime</code> processor, which parses a
 	 * String as a LocalTime, accepting the same format as {@link LocalTime#parse(CharSequence)}
 	 *
 	 */
@@ -46,7 +46,7 @@ public class ParseLocalTime extends AbstractTemporalAccessorParsingProcessor<Loc
 	}
 
 	/**
-	 * Constructs a new <tt>ParseLocalTime</tt> processor, which parses a
+	 * Constructs a new <code>ParseLocalTime</code> processor, which parses a
 	 * String as a LocalTime, then calls the next processor in the
 	 * chain.
 	 *
@@ -59,7 +59,7 @@ public class ParseLocalTime extends AbstractTemporalAccessorParsingProcessor<Loc
 	}
 
 	/**
-	 * Constructs a new <tt>ParseLocalTime</tt> processor, which parses a
+	 * Constructs a new <code>ParseLocalTime</code> processor, which parses a
 	 * String as a LocalTime using the supplied formatter.
 	 *
 	 * @param formatter the formatter used for parsing
@@ -70,7 +70,7 @@ public class ParseLocalTime extends AbstractTemporalAccessorParsingProcessor<Loc
 	}
 
 	/**
-	 * Constructs a new <tt>ParseLocalTime</tt> processor, which parses a
+	 * Constructs a new <code>ParseLocalTime</code> processor, which parses a
 	 * String as a LocalTime using the supplied formatter, then calls
 	 * the next processor in the chain.
 	 *

--- a/super-csv-java8/src/main/java/org/supercsv/cellprocessor/time/ParsePeriod.java
+++ b/super-csv-java8/src/main/java/org/supercsv/cellprocessor/time/ParsePeriod.java
@@ -36,7 +36,7 @@ import org.supercsv.util.CsvContext;
 public class ParsePeriod extends CellProcessorAdaptor implements StringCellProcessor {
 
 	/**
-	 * Constructs a new <tt>ParsePeriod</tt> processor, which parses a String as
+	 * Constructs a new <code>ParsePeriod</code> processor, which parses a String as
 	 * a Period.
 	 */
 	public ParsePeriod() {
@@ -44,7 +44,7 @@ public class ParsePeriod extends CellProcessorAdaptor implements StringCellProce
 	}
 
 	/**
-	 * Constructs a new <tt>ParsePeriod</tt> processor, which parses a String as
+	 * Constructs a new <code>ParsePeriod</code> processor, which parses a String as
 	 * a Period, then calls the next processor in the chain.
 	 *
 	 * @param next the next processor in the chain

--- a/super-csv-java8/src/main/java/org/supercsv/cellprocessor/time/ParseZoneId.java
+++ b/super-csv-java8/src/main/java/org/supercsv/cellprocessor/time/ParseZoneId.java
@@ -37,7 +37,7 @@ public class ParseZoneId extends CellProcessorAdaptor implements StringCellProce
 	private final Map<String, String> aliasMap;
 
 	/**
-	 * Constructs a new <tt>ParseZoneId</tt> processor, which parses a
+	 * Constructs a new <code>ParseZoneId</code> processor, which parses a
 	 * String recognized by {@link ZoneId#of(String)} as a ZoneId.
 	 */
 	public ParseZoneId() {
@@ -45,7 +45,7 @@ public class ParseZoneId extends CellProcessorAdaptor implements StringCellProce
 	}
 
 	/**
-	 * Constructs a new <tt>ParseZoneId</tt> processor, which parses a
+	 * Constructs a new <code>ParseZoneId</code> processor, which parses a
 	 * String as a ZoneId, then calls the next processor in the
 	 * chain.
 	 *
@@ -58,7 +58,7 @@ public class ParseZoneId extends CellProcessorAdaptor implements StringCellProce
 	}
 
 	/**
-	 * Constructs a new <tt>ParseZoneId</tt> processor, which parses a
+	 * Constructs a new <code>ParseZoneId</code> processor, which parses a
 	 * String as a ZoneId using the supplied Zone ID mappings.
 	 *
 	 * @param aliasMap a Map from custom zone IDs to canonical representations
@@ -70,7 +70,7 @@ public class ParseZoneId extends CellProcessorAdaptor implements StringCellProce
 	}
 
 	/**
-	 * Constructs a new <tt>ParseZoneId</tt> processor, which parses a
+	 * Constructs a new <code>ParseZoneId</code> processor, which parses a
 	 * String as a ZoneId using the supplied Zone ID mappings, then calls the next processor in the
 	 * chain.
 	 *

--- a/super-csv-java8/src/main/java/org/supercsv/cellprocessor/time/ParseZonedDateTime.java
+++ b/super-csv-java8/src/main/java/org/supercsv/cellprocessor/time/ParseZonedDateTime.java
@@ -38,7 +38,7 @@ import org.supercsv.cellprocessor.ift.CellProcessor;
 public class ParseZonedDateTime extends AbstractTemporalAccessorParsingProcessor<ZonedDateTime> {
 
 	/**
-	 * Constructs a new <tt>ParseZonedDateTime</tt> processor, which parses a String
+	 * Constructs a new <code>ParseZonedDateTime</code> processor, which parses a String
 	 * in the same format accepted by {@link ZonedDateTime#parse(CharSequence)}
 	 * as a ZonedDateTime.
 	 */
@@ -47,7 +47,7 @@ public class ParseZonedDateTime extends AbstractTemporalAccessorParsingProcessor
 	}
 
 	/**
-	 * Constructs a new <tt>ParseZonedDateTime</tt> processor, which parses a String
+	 * Constructs a new <code>ParseZonedDateTime</code> processor, which parses a String
 	 * as a ZonedDateTime, then calls the next processor in the chain.
 	 *
 	 * @param next the next processor in the chain
@@ -59,7 +59,7 @@ public class ParseZonedDateTime extends AbstractTemporalAccessorParsingProcessor
 	}
 
 	/**
-	 * Constructs a new <tt>ParseZonedDateTime</tt> processor, which parses a String
+	 * Constructs a new <code>ParseZonedDateTime</code> processor, which parses a String
 	 * as a ZonedDateTime using the supplied formatter.
 	 *
 	 * @param formatter the formatter used for parsing
@@ -70,7 +70,7 @@ public class ParseZonedDateTime extends AbstractTemporalAccessorParsingProcessor
 	}
 
 	/**
-	 * Constructs a new <tt>ParseZonedDateTime</tt> processor, which parses a String
+	 * Constructs a new <code>ParseZonedDateTime</code> processor, which parses a String
 	 * as a ZonedDateTime using the supplied formatter, then calls the next
 	 * processor in the chain.
 	 *

--- a/super-csv-java8/src/main/java/org/supercsv/cellprocessor/time/package-info.java
+++ b/super-csv-java8/src/main/java/org/supercsv/cellprocessor/time/package-info.java
@@ -14,6 +14,6 @@
  * limitations under the License.
  */
 /**
- * Provides <tt>CellProcessor</tt> classes for converting, formatting and parsing {@link java.time} classes.
+ * Provides <code>CellProcessor</code> classes for converting, formatting and parsing {@link java.time} classes.
  */
 package org.supercsv.cellprocessor.time;

--- a/super-csv-java8/src/main/java/org/supercsv/io/CsvTypedBeanWriter.java
+++ b/super-csv-java8/src/main/java/org/supercsv/io/CsvTypedBeanWriter.java
@@ -32,8 +32,8 @@ public final class CsvTypedBeanWriter<T> implements ICsvTypedBeanWriter<T> {
     private final ICsvListWriter writer;
 
     /**
-     * Constructs a new <tt>CsvTypedBeanWriter</tt> with the supplied Writer and CSV preferences.
-     * Note that the <tt>writer</tt> will be wrapped in a <tt>BufferedWriter</tt> before accessed.
+     * Constructs a new <code>CsvTypedBeanWriter</code> with the supplied Writer and CSV preferences.
+     * Note that the <code>writer</code> will be wrapped in a <code>BufferedWriter</code> before accessed.
      *
      * @param writer the writer
      * @param preference the CSV preferences

--- a/super-csv-java8/src/test/java/org/supercsv/cellprocessor/time/mock/IdentityTransform.java
+++ b/super-csv-java8/src/test/java/org/supercsv/cellprocessor/time/mock/IdentityTransform.java
@@ -28,7 +28,7 @@ public class IdentityTransform extends CellProcessorAdaptor implements BoolCellP
 	DoubleCellProcessor, LongCellProcessor, StringCellProcessor {
 	
 	/**
-	 * Constructs a new <tt>IdentityTransform</tt> processor, which simply returns whatever is passed into it.
+	 * Constructs a new <code>IdentityTransform</code> processor, which simply returns whatever is passed into it.
 	 */
 	public IdentityTransform() {
 		super();

--- a/super-csv-joda/src/main/java/org/supercsv/cellprocessor/joda/AbstractJodaFormattingProcessor.java
+++ b/super-csv-joda/src/main/java/org/supercsv/cellprocessor/joda/AbstractJodaFormattingProcessor.java
@@ -43,7 +43,7 @@ public abstract class AbstractJodaFormattingProcessor<T> extends
 	private final Locale locale;
 
 	/**
-	 * Constructs a new <tt>AbstractJodaFormattingProcessor</tt> processor,
+	 * Constructs a new <code>AbstractJodaFormattingProcessor</code> processor,
 	 * which formats the Joda type as a String.
 	 * 
 	 * @param jodaClass
@@ -61,7 +61,7 @@ public abstract class AbstractJodaFormattingProcessor<T> extends
 	}
 
 	/**
-	 * Constructs a new <tt>AbstractJodaFormattingProcessor</tt> processor,
+	 * Constructs a new <code>AbstractJodaFormattingProcessor</code> processor,
 	 * which formats the Joda type as a String, then calls the next processor in
 	 * the chain.
 	 * 
@@ -84,7 +84,7 @@ public abstract class AbstractJodaFormattingProcessor<T> extends
 	}
 
 	/**
-	 * Constructs a new <tt>AbstractJodaFormattingProcessor</tt> processor,
+	 * Constructs a new <code>AbstractJodaFormattingProcessor</code> processor,
 	 * which formats the Joda type as a String using the supplied formatter.
 	 * 
 	 * @param jodaClass
@@ -104,7 +104,7 @@ public abstract class AbstractJodaFormattingProcessor<T> extends
 	}
 
 	/**
-	 * Constructs a new <tt>AbstractJodaFormattingProcessor</tt> processor,
+	 * Constructs a new <code>AbstractJodaFormattingProcessor</code> processor,
 	 * which formats the Joda type as a String using the supplied formatter,
 	 * then calls the next processor in the chain.
 	 * 
@@ -128,7 +128,7 @@ public abstract class AbstractJodaFormattingProcessor<T> extends
 	}
 
 	/**
-	 * Constructs a new <tt>AbstractJodaFormattingProcessor</tt> processor,
+	 * Constructs a new <code>AbstractJodaFormattingProcessor</code> processor,
 	 * which formats the Joda type as a String using the supplied pattern and
 	 * the default locale.
 	 * 
@@ -145,7 +145,7 @@ public abstract class AbstractJodaFormattingProcessor<T> extends
 	}
 
 	/**
-	 * Constructs a new <tt>AbstractJodaFormattingProcessor</tt> processor,
+	 * Constructs a new <code>AbstractJodaFormattingProcessor</code> processor,
 	 * which formats the Joda type as a String using the supplied pattern and
 	 * the default locale, then calls the next processor in the chain.
 	 * 
@@ -164,7 +164,7 @@ public abstract class AbstractJodaFormattingProcessor<T> extends
 	}
 
 	/**
-	 * Constructs a new <tt>AbstractJodaFormattingProcessor</tt> processor,
+	 * Constructs a new <code>AbstractJodaFormattingProcessor</code> processor,
 	 * which formats the Joda type as a String using the supplied pattern and
 	 * the locale.
 	 * 
@@ -173,7 +173,7 @@ public abstract class AbstractJodaFormattingProcessor<T> extends
 	 * @param pattern
 	 *            the pattern to use
 	 * @param locale
-	 *            the locale to use (default used if <tt>null</tt>)
+	 *            the locale to use (default used if <code>null</code>)
 	 * @throws NullPointerException
 	 *             if jodaClass or pattern is null
 	 */
@@ -187,7 +187,7 @@ public abstract class AbstractJodaFormattingProcessor<T> extends
 	}
 
 	/**
-	 * Constructs a new <tt>AbstractJodaFormattingProcessor</tt> processor,
+	 * Constructs a new <code>AbstractJodaFormattingProcessor</code> processor,
 	 * which formats the Joda type as a String using the supplied pattern and
 	 * the locale, then calls the next processor in the chain.
 	 * 
@@ -196,7 +196,7 @@ public abstract class AbstractJodaFormattingProcessor<T> extends
 	 * @param pattern
 	 *            the pattern to use
 	 * @param locale
-	 *            the locale to use (default used if <tt>null</tt>)
+	 *            the locale to use (default used if <code>null</code>)
 	 * @param next
 	 *            the next processor in the chain
 	 * @throws NullPointerException

--- a/super-csv-joda/src/main/java/org/supercsv/cellprocessor/joda/AbstractJodaParsingProcessor.java
+++ b/super-csv-joda/src/main/java/org/supercsv/cellprocessor/joda/AbstractJodaParsingProcessor.java
@@ -36,7 +36,7 @@ public abstract class AbstractJodaParsingProcessor<T> extends
 	private final DateTimeFormatter formatter;
 
 	/**
-	 * Constructs a new <tt>AbstractJodaParsingProcessor</tt> processor, which
+	 * Constructs a new <code>AbstractJodaParsingProcessor</code> processor, which
 	 * parses a String as a Joda type.
 	 */
 	public AbstractJodaParsingProcessor() {
@@ -44,7 +44,7 @@ public abstract class AbstractJodaParsingProcessor<T> extends
 	}
 
 	/**
-	 * Constructs a new <tt>AbstractJodaParsingProcessor</tt> processor, which
+	 * Constructs a new <code>AbstractJodaParsingProcessor</code> processor, which
 	 * parses a String as a Joda type, then calls the next processor in the
 	 * chain.
 	 * 
@@ -59,7 +59,7 @@ public abstract class AbstractJodaParsingProcessor<T> extends
 	}
 
 	/**
-	 * Constructs a new <tt>AbstractJodaParsingProcessor</tt> processor, which
+	 * Constructs a new <code>AbstractJodaParsingProcessor</code> processor, which
 	 * parses a String as a Joda type using the supplied formatter.
 	 * 
 	 * @param formatter
@@ -73,7 +73,7 @@ public abstract class AbstractJodaParsingProcessor<T> extends
 	}
 
 	/**
-	 * Constructs a new <tt>AbstractJodaParsingProcessor</tt> processor, which
+	 * Constructs a new <code>AbstractJodaParsingProcessor</code> processor, which
 	 * parses a String as a Joda type using the supplied formatter, then calls
 	 * the next processor in the chain.
 	 * 

--- a/super-csv-joda/src/main/java/org/supercsv/cellprocessor/joda/FmtDateTime.java
+++ b/super-csv-joda/src/main/java/org/supercsv/cellprocessor/joda/FmtDateTime.java
@@ -47,7 +47,7 @@ public class FmtDateTime extends AbstractJodaFormattingProcessor<DateTime> {
 	private static final Class<DateTime> JODA_CLASS = DateTime.class;
 
 	/**
-	 * Constructs a new <tt>FmtDateTime</tt> processor, which formats a Joda
+	 * Constructs a new <code>FmtDateTime</code> processor, which formats a Joda
 	 * DateTime as a String.
 	 */
 	public FmtDateTime() {
@@ -55,7 +55,7 @@ public class FmtDateTime extends AbstractJodaFormattingProcessor<DateTime> {
 	}
 
 	/**
-	 * Constructs a new <tt>FmtDateTime</tt> processor, which formats a Joda
+	 * Constructs a new <code>FmtDateTime</code> processor, which formats a Joda
 	 * DateTime as a String, then calls the next processor in the chain.
 	 * 
 	 * @param next
@@ -68,7 +68,7 @@ public class FmtDateTime extends AbstractJodaFormattingProcessor<DateTime> {
 	}
 
 	/**
-	 * Constructs a new <tt>FmtDateTime</tt> processor, which formats a Joda
+	 * Constructs a new <code>FmtDateTime</code> processor, which formats a Joda
 	 * DateTime as a String using the supplied formatter.
 	 * 
 	 * @param formatter
@@ -81,7 +81,7 @@ public class FmtDateTime extends AbstractJodaFormattingProcessor<DateTime> {
 	}
 
 	/**
-	 * Constructs a new <tt>FmtDateTime</tt> processor, which formats a Joda
+	 * Constructs a new <code>FmtDateTime</code> processor, which formats a Joda
 	 * DateTime as a String using the supplied formatter, then calls the next
 	 * processor in the chain.
 	 * 
@@ -98,7 +98,7 @@ public class FmtDateTime extends AbstractJodaFormattingProcessor<DateTime> {
 	}
 
 	/**
-	 * Constructs a new <tt>FmtDateTime</tt> processor, which formats a Joda
+	 * Constructs a new <code>FmtDateTime</code> processor, which formats a Joda
 	 * DateTime as a String using the supplied pattern and the default locale.
 	 * 
 	 * @param pattern
@@ -111,7 +111,7 @@ public class FmtDateTime extends AbstractJodaFormattingProcessor<DateTime> {
 	}
 
 	/**
-	 * Constructs a new <tt>FmtDateTime</tt> processor, which formats a Joda
+	 * Constructs a new <code>FmtDateTime</code> processor, which formats a Joda
 	 * DateTime as a String using the supplied pattern and the default locale,
 	 * then calls the next processor in the chain.
 	 * 
@@ -127,13 +127,13 @@ public class FmtDateTime extends AbstractJodaFormattingProcessor<DateTime> {
 	}
 
 	/**
-	 * Constructs a new <tt>FmtDateTime</tt> processor, which formats a Joda
+	 * Constructs a new <code>FmtDateTime</code> processor, which formats a Joda
 	 * DateTime as a String using the supplied pattern and the locale.
 	 * 
 	 * @param pattern
 	 *            the pattern to use
 	 * @param locale
-	 *            the locale to use (default used if <tt>null</tt>)
+	 *            the locale to use (default used if <code>null</code>)
 	 * @throws NullPointerException
 	 *             if pattern is null
 	 */
@@ -142,14 +142,14 @@ public class FmtDateTime extends AbstractJodaFormattingProcessor<DateTime> {
 	}
 
 	/**
-	 * Constructs a new <tt>FmtDateTime</tt> processor, which formats a Joda
+	 * Constructs a new <code>FmtDateTime</code> processor, which formats a Joda
 	 * DateTime as a String using the supplied pattern and the locale, then
 	 * calls the next processor in the chain.
 	 * 
 	 * @param pattern
 	 *            the pattern to use
 	 * @param locale
-	 *            the locale to use (default used if <tt>null</tt>)
+	 *            the locale to use (default used if <code>null</code>)
 	 * @param next
 	 *            the next processor in the chain
 	 * @throws NullPointerException

--- a/super-csv-joda/src/main/java/org/supercsv/cellprocessor/joda/FmtDateTimeZone.java
+++ b/super-csv-joda/src/main/java/org/supercsv/cellprocessor/joda/FmtDateTimeZone.java
@@ -31,14 +31,14 @@ import org.supercsv.util.CsvContext;
 public class FmtDateTimeZone extends CellProcessorAdaptor {
 
 	/**
-	 * Constructs a new <tt>FmtDateTimeZone</tt> processor, which formats a Joda
+	 * Constructs a new <code>FmtDateTimeZone</code> processor, which formats a Joda
 	 * DateTimeZone as a String.
 	 */
 	public FmtDateTimeZone() {
 	}
 
 	/**
-	 * Constructs a new <tt>FmtDateTimeZone</tt> processor, which formats a Joda
+	 * Constructs a new <code>FmtDateTimeZone</code> processor, which formats a Joda
 	 * DateTimeZone as a String, then calls the next processor in the chain.
 	 * 
 	 * @param next

--- a/super-csv-joda/src/main/java/org/supercsv/cellprocessor/joda/FmtDuration.java
+++ b/super-csv-joda/src/main/java/org/supercsv/cellprocessor/joda/FmtDuration.java
@@ -35,14 +35,14 @@ import org.supercsv.util.CsvContext;
 public class FmtDuration extends CellProcessorAdaptor {
 
 	/**
-	 * Constructs a new <tt>FmtDuration</tt> processor, which formats a Joda
+	 * Constructs a new <code>FmtDuration</code> processor, which formats a Joda
 	 * Duration as a String.
 	 */
 	public FmtDuration() {
 	}
 
 	/**
-	 * Constructs a new <tt>FmtDuration</tt> processor, which formats a Joda
+	 * Constructs a new <code>FmtDuration</code> processor, which formats a Joda
 	 * Duration as a String, then calls the next processor in the chain.
 	 * 
 	 * @param next

--- a/super-csv-joda/src/main/java/org/supercsv/cellprocessor/joda/FmtInterval.java
+++ b/super-csv-joda/src/main/java/org/supercsv/cellprocessor/joda/FmtInterval.java
@@ -30,14 +30,14 @@ import org.supercsv.util.CsvContext;
 public class FmtInterval extends CellProcessorAdaptor {
 
 	/**
-	 * Constructs a new <tt>FmtInterval</tt> processor, which formats a Joda
+	 * Constructs a new <code>FmtInterval</code> processor, which formats a Joda
 	 * Interval as a String.
 	 */
 	public FmtInterval() {
 	}
 
 	/**
-	 * Constructs a new <tt>FmtInterval</tt> processor, which formats a Joda
+	 * Constructs a new <code>FmtInterval</code> processor, which formats a Joda
 	 * Interval as a String, then calls the next processor in the chain.
 	 * 
 	 * @param next

--- a/super-csv-joda/src/main/java/org/supercsv/cellprocessor/joda/FmtLocalDate.java
+++ b/super-csv-joda/src/main/java/org/supercsv/cellprocessor/joda/FmtLocalDate.java
@@ -48,7 +48,7 @@ public class FmtLocalDate extends AbstractJodaFormattingProcessor<LocalDate> {
 	private static final Class<LocalDate> JODA_CLASS = LocalDate.class;
 
 	/**
-	 * Constructs a new <tt>FmtLocalDate</tt> processor, which formats a Joda
+	 * Constructs a new <code>FmtLocalDate</code> processor, which formats a Joda
 	 * LocalDate as a String.
 	 */
 	public FmtLocalDate() {
@@ -56,7 +56,7 @@ public class FmtLocalDate extends AbstractJodaFormattingProcessor<LocalDate> {
 	}
 
 	/**
-	 * Constructs a new <tt>FmtLocalDate</tt> processor, which formats a Joda
+	 * Constructs a new <code>FmtLocalDate</code> processor, which formats a Joda
 	 * LocalDate as a String, then calls the next processor in the chain.
 	 * 
 	 * @param next
@@ -69,7 +69,7 @@ public class FmtLocalDate extends AbstractJodaFormattingProcessor<LocalDate> {
 	}
 
 	/**
-	 * Constructs a new <tt>FmtLocalDate</tt> processor, which formats a Joda
+	 * Constructs a new <code>FmtLocalDate</code> processor, which formats a Joda
 	 * LocalDate as a String using the supplied formatter.
 	 * 
 	 * @param formatter
@@ -82,7 +82,7 @@ public class FmtLocalDate extends AbstractJodaFormattingProcessor<LocalDate> {
 	}
 
 	/**
-	 * Constructs a new <tt>FmtLocalDate</tt> processor, which formats a Joda
+	 * Constructs a new <code>FmtLocalDate</code> processor, which formats a Joda
 	 * LocalDate as a String using the supplied formatter, then calls the next
 	 * processor in the chain.
 	 * 
@@ -99,7 +99,7 @@ public class FmtLocalDate extends AbstractJodaFormattingProcessor<LocalDate> {
 	}
 
 	/**
-	 * Constructs a new <tt>FmtLocalDate</tt> processor, which formats a Joda
+	 * Constructs a new <code>FmtLocalDate</code> processor, which formats a Joda
 	 * LocalDate as a String using the supplied pattern and the default locale.
 	 * 
 	 * @param pattern
@@ -112,7 +112,7 @@ public class FmtLocalDate extends AbstractJodaFormattingProcessor<LocalDate> {
 	}
 
 	/**
-	 * Constructs a new <tt>FmtLocalDate</tt> processor, which formats a Joda
+	 * Constructs a new <code>FmtLocalDate</code> processor, which formats a Joda
 	 * LocalDate as a String using the supplied pattern and the default locale,
 	 * then calls the next processor in the chain.
 	 * 
@@ -128,13 +128,13 @@ public class FmtLocalDate extends AbstractJodaFormattingProcessor<LocalDate> {
 	}
 
 	/**
-	 * Constructs a new <tt>FmtLocalDate</tt> processor, which formats a Joda
+	 * Constructs a new <code>FmtLocalDate</code> processor, which formats a Joda
 	 * LocalDate as a String using the supplied pattern and the locale.
 	 * 
 	 * @param pattern
 	 *            the pattern to use
 	 * @param locale
-	 *            the locale to use (default used if <tt>null</tt>)
+	 *            the locale to use (default used if <code>null</code>)
 	 * @throws NullPointerException
 	 *             if pattern is null
 	 */
@@ -143,14 +143,14 @@ public class FmtLocalDate extends AbstractJodaFormattingProcessor<LocalDate> {
 	}
 
 	/**
-	 * Constructs a new <tt>FmtLocalDate</tt> processor, which formats a Joda
+	 * Constructs a new <code>FmtLocalDate</code> processor, which formats a Joda
 	 * LocalDate as a String using the supplied pattern and the locale, then
 	 * calls the next processor in the chain.
 	 * 
 	 * @param pattern
 	 *            the pattern to use
 	 * @param locale
-	 *            the locale to use (default used if <tt>null</tt>)
+	 *            the locale to use (default used if <code>null</code>)
 	 * @param next
 	 *            the next processor in the chain
 	 * @throws NullPointerException

--- a/super-csv-joda/src/main/java/org/supercsv/cellprocessor/joda/FmtLocalDateTime.java
+++ b/super-csv-joda/src/main/java/org/supercsv/cellprocessor/joda/FmtLocalDateTime.java
@@ -49,7 +49,7 @@ public class FmtLocalDateTime extends
 	private static final Class<LocalDateTime> JODA_CLASS = LocalDateTime.class;
 
 	/**
-	 * Constructs a new <tt>FmtLocalDateTime</tt> processor, which formats a
+	 * Constructs a new <code>FmtLocalDateTime</code> processor, which formats a
 	 * Joda LocalDateTime as a String.
 	 */
 	public FmtLocalDateTime() {
@@ -57,7 +57,7 @@ public class FmtLocalDateTime extends
 	}
 
 	/**
-	 * Constructs a new <tt>FmtLocalDateTime</tt> processor, which formats a
+	 * Constructs a new <code>FmtLocalDateTime</code> processor, which formats a
 	 * Joda LocalDateTime as a String, then calls the next processor in the
 	 * chain.
 	 * 
@@ -71,7 +71,7 @@ public class FmtLocalDateTime extends
 	}
 
 	/**
-	 * Constructs a new <tt>FmtLocalDateTime</tt> processor, which formats a
+	 * Constructs a new <code>FmtLocalDateTime</code> processor, which formats a
 	 * Joda LocalDateTime as a String using the supplied formatter.
 	 * 
 	 * @param formatter
@@ -84,7 +84,7 @@ public class FmtLocalDateTime extends
 	}
 
 	/**
-	 * Constructs a new <tt>FmtLocalDateTime</tt> processor, which formats a
+	 * Constructs a new <code>FmtLocalDateTime</code> processor, which formats a
 	 * Joda LocalDateTime as a String using the supplied formatter, then calls
 	 * the next processor in the chain.
 	 * 
@@ -101,7 +101,7 @@ public class FmtLocalDateTime extends
 	}
 
 	/**
-	 * Constructs a new <tt>FmtLocalDateTime</tt> processor, which formats a
+	 * Constructs a new <code>FmtLocalDateTime</code> processor, which formats a
 	 * Joda LocalDateTime as a String using the supplied pattern and the default
 	 * locale.
 	 * 
@@ -115,7 +115,7 @@ public class FmtLocalDateTime extends
 	}
 
 	/**
-	 * Constructs a new <tt>FmtLocalDateTime</tt> processor, which formats a
+	 * Constructs a new <code>FmtLocalDateTime</code> processor, which formats a
 	 * Joda LocalDateTime as a String using the supplied pattern and the default
 	 * locale, then calls the next processor in the chain.
 	 * 
@@ -131,13 +131,13 @@ public class FmtLocalDateTime extends
 	}
 
 	/**
-	 * Constructs a new <tt>FmtLocalDateTime</tt> processor, which formats a
+	 * Constructs a new <code>FmtLocalDateTime</code> processor, which formats a
 	 * Joda LocalDateTime as a String using the supplied pattern and the locale.
 	 * 
 	 * @param pattern
 	 *            the pattern to use
 	 * @param locale
-	 *            the locale to use (default used if <tt>null</tt>)
+	 *            the locale to use (default used if <code>null</code>)
 	 * @throws NullPointerException
 	 *             if pattern is null
 	 */
@@ -146,14 +146,14 @@ public class FmtLocalDateTime extends
 	}
 
 	/**
-	 * Constructs a new <tt>FmtLocalDateTime</tt> processor, which formats a
+	 * Constructs a new <code>FmtLocalDateTime</code> processor, which formats a
 	 * Joda LocalDateTime as a String using the supplied pattern and the locale,
 	 * then calls the next processor in the chain.
 	 * 
 	 * @param pattern
 	 *            the pattern to use
 	 * @param locale
-	 *            the locale to use (default used if <tt>null</tt>)
+	 *            the locale to use (default used if <code>null</code>)
 	 * @param next
 	 *            the next processor in the chain
 	 * @throws NullPointerException

--- a/super-csv-joda/src/main/java/org/supercsv/cellprocessor/joda/FmtLocalTime.java
+++ b/super-csv-joda/src/main/java/org/supercsv/cellprocessor/joda/FmtLocalTime.java
@@ -48,7 +48,7 @@ public class FmtLocalTime extends AbstractJodaFormattingProcessor<LocalTime> {
 	private static final Class<LocalTime> JODA_CLASS = LocalTime.class;
 
 	/**
-	 * Constructs a new <tt>FmtLocalTime</tt> processor, which formats a Joda
+	 * Constructs a new <code>FmtLocalTime</code> processor, which formats a Joda
 	 * LocalTime as a String.
 	 */
 	public FmtLocalTime() {
@@ -56,7 +56,7 @@ public class FmtLocalTime extends AbstractJodaFormattingProcessor<LocalTime> {
 	}
 
 	/**
-	 * Constructs a new <tt>FmtLocalTime</tt> processor, which formats a Joda
+	 * Constructs a new <code>FmtLocalTime</code> processor, which formats a Joda
 	 * LocalTime as a String, then calls the next processor in the chain.
 	 * 
 	 * @param next
@@ -69,7 +69,7 @@ public class FmtLocalTime extends AbstractJodaFormattingProcessor<LocalTime> {
 	}
 
 	/**
-	 * Constructs a new <tt>FmtLocalTime</tt> processor, which formats a Joda
+	 * Constructs a new <code>FmtLocalTime</code> processor, which formats a Joda
 	 * LocalTime as a String using the supplied formatter.
 	 * 
 	 * @param formatter
@@ -82,7 +82,7 @@ public class FmtLocalTime extends AbstractJodaFormattingProcessor<LocalTime> {
 	}
 
 	/**
-	 * Constructs a new <tt>FmtLocalTime</tt> processor, which formats a Joda
+	 * Constructs a new <code>FmtLocalTime</code> processor, which formats a Joda
 	 * LocalTime as a String using the supplied formatter, then calls the next
 	 * processor in the chain.
 	 * 
@@ -99,7 +99,7 @@ public class FmtLocalTime extends AbstractJodaFormattingProcessor<LocalTime> {
 	}
 
 	/**
-	 * Constructs a new <tt>FmtLocalTime</tt> processor, which formats a Joda
+	 * Constructs a new <code>FmtLocalTime</code> processor, which formats a Joda
 	 * LocalTime as a String using the supplied pattern and the default locale.
 	 * 
 	 * @param pattern
@@ -112,7 +112,7 @@ public class FmtLocalTime extends AbstractJodaFormattingProcessor<LocalTime> {
 	}
 
 	/**
-	 * Constructs a new <tt>FmtLocalTime</tt> processor, which formats a Joda
+	 * Constructs a new <code>FmtLocalTime</code> processor, which formats a Joda
 	 * LocalTime as a String using the supplied pattern and the default locale,
 	 * then calls the next processor in the chain.
 	 * 
@@ -128,13 +128,13 @@ public class FmtLocalTime extends AbstractJodaFormattingProcessor<LocalTime> {
 	}
 
 	/**
-	 * Constructs a new <tt>FmtLocalTime</tt> processor, which formats a Joda
+	 * Constructs a new <code>FmtLocalTime</code> processor, which formats a Joda
 	 * LocalTime as a String using the supplied pattern and the locale.
 	 * 
 	 * @param pattern
 	 *            the pattern to use
 	 * @param locale
-	 *            the locale to use (default used if <tt>null</tt>)
+	 *            the locale to use (default used if <code>null</code>)
 	 * @throws NullPointerException
 	 *             if pattern is null
 	 */
@@ -143,14 +143,14 @@ public class FmtLocalTime extends AbstractJodaFormattingProcessor<LocalTime> {
 	}
 
 	/**
-	 * Constructs a new <tt>FmtLocalTime</tt> processor, which formats a Joda
+	 * Constructs a new <code>FmtLocalTime</code> processor, which formats a Joda
 	 * LocalTime as a String using the supplied pattern and the locale, then
 	 * calls the next processor in the chain.
 	 * 
 	 * @param pattern
 	 *            the pattern to use
 	 * @param locale
-	 *            the locale to use (default used if <tt>null</tt>)
+	 *            the locale to use (default used if <code>null</code>)
 	 * @param next
 	 *            the next processor in the chain
 	 * @throws NullPointerException

--- a/super-csv-joda/src/main/java/org/supercsv/cellprocessor/joda/FmtPeriod.java
+++ b/super-csv-joda/src/main/java/org/supercsv/cellprocessor/joda/FmtPeriod.java
@@ -50,7 +50,7 @@ public class FmtPeriod extends CellProcessorAdaptor {
 	private final PeriodFormatter formatter;
 
 	/**
-	 * Constructs a new <tt>FmtPeriod</tt> processor, which formats a Joda
+	 * Constructs a new <code>FmtPeriod</code> processor, which formats a Joda
 	 * Period as a String.
 	 */
 	public FmtPeriod() {
@@ -58,7 +58,7 @@ public class FmtPeriod extends CellProcessorAdaptor {
 	}
 
 	/**
-	 * Constructs a new <tt>FmtPeriod</tt> processor, which formats a Joda
+	 * Constructs a new <code>FmtPeriod</code> processor, which formats a Joda
 	 * Period as a String, then calls the next processor in the chain.
 	 * 
 	 * @param next
@@ -72,7 +72,7 @@ public class FmtPeriod extends CellProcessorAdaptor {
 	}
 
 	/**
-	 * Constructs a new <tt>FmtPeriod</tt> processor, which formats a Joda
+	 * Constructs a new <code>FmtPeriod</code> processor, which formats a Joda
 	 * Period as a String using the supplied formatter.
 	 * 
 	 * @param formatter
@@ -86,7 +86,7 @@ public class FmtPeriod extends CellProcessorAdaptor {
 	}
 
 	/**
-	 * Constructs a new <tt>FmtPeriod</tt> processor, which formats a Joda
+	 * Constructs a new <code>FmtPeriod</code> processor, which formats a Joda
 	 * Period as a String using the supplied formatter, then calls the next
 	 * processor in the chain.
 	 * 

--- a/super-csv-joda/src/main/java/org/supercsv/cellprocessor/joda/ParseDateTime.java
+++ b/super-csv-joda/src/main/java/org/supercsv/cellprocessor/joda/ParseDateTime.java
@@ -44,14 +44,14 @@ import org.supercsv.cellprocessor.ift.CellProcessor;
 public class ParseDateTime extends AbstractJodaParsingProcessor<DateTime> {
 
 	/**
-	 * Constructs a new <tt>ParseDateTime</tt> processor, which parses a String
+	 * Constructs a new <code>ParseDateTime</code> processor, which parses a String
 	 * as a Joda DateTime.
 	 */
 	public ParseDateTime() {
 	}
 
 	/**
-	 * Constructs a new <tt>ParseDateTime</tt> processor, which parses a String
+	 * Constructs a new <code>ParseDateTime</code> processor, which parses a String
 	 * as a Joda DateTime, then calls the next processor in the chain.
 	 * 
 	 * @param next
@@ -64,7 +64,7 @@ public class ParseDateTime extends AbstractJodaParsingProcessor<DateTime> {
 	}
 
 	/**
-	 * Constructs a new <tt>ParseDateTime</tt> processor, which parses a String
+	 * Constructs a new <code>ParseDateTime</code> processor, which parses a String
 	 * as a Joda DateTime using the supplied formatter.
 	 * 
 	 * @param formatter
@@ -77,7 +77,7 @@ public class ParseDateTime extends AbstractJodaParsingProcessor<DateTime> {
 	}
 
 	/**
-	 * Constructs a new <tt>ParseDateTime</tt> processor, which parses a String
+	 * Constructs a new <code>ParseDateTime</code> processor, which parses a String
 	 * as a Joda DateTime using the supplied formatter, then calls the next
 	 * processor in the chain.
 	 * 

--- a/super-csv-joda/src/main/java/org/supercsv/cellprocessor/joda/ParseDateTimeZone.java
+++ b/super-csv-joda/src/main/java/org/supercsv/cellprocessor/joda/ParseDateTimeZone.java
@@ -32,14 +32,14 @@ import org.supercsv.util.CsvContext;
 public class ParseDateTimeZone extends CellProcessorAdaptor implements StringCellProcessor {
 
 	/**
-	 * Constructs a new <tt>ParseDateTimeZone</tt> processor, which parses a
+	 * Constructs a new <code>ParseDateTimeZone</code> processor, which parses a
 	 * String as a Joda DateTimeZone.
 	 */
 	public ParseDateTimeZone() {
 	}
 
 	/**
-	 * Constructs a new <tt>ParseDateTimeZone</tt> processor, which parses a
+	 * Constructs a new <code>ParseDateTimeZone</code> processor, which parses a
 	 * String as a Joda DateTimeZone, then calls the next processor in the
 	 * chain.
 	 * 

--- a/super-csv-joda/src/main/java/org/supercsv/cellprocessor/joda/ParseDuration.java
+++ b/super-csv-joda/src/main/java/org/supercsv/cellprocessor/joda/ParseDuration.java
@@ -38,14 +38,14 @@ import org.supercsv.util.CsvContext;
 public class ParseDuration extends CellProcessorAdaptor implements StringCellProcessor {
 
 	/**
-	 * Constructs a new <tt>ParseDuration</tt> processor, which parses a String
+	 * Constructs a new <code>ParseDuration</code> processor, which parses a String
 	 * as a Joda Duration.
 	 */
 	public ParseDuration() {
 	}
 
 	/**
-	 * Constructs a new <tt>ParseDuration</tt> processor, which parses a String
+	 * Constructs a new <code>ParseDuration</code> processor, which parses a String
 	 * as a Joda Duration, then calls the next processor in the chain.
 	 * 
 	 * @param next

--- a/super-csv-joda/src/main/java/org/supercsv/cellprocessor/joda/ParseInterval.java
+++ b/super-csv-joda/src/main/java/org/supercsv/cellprocessor/joda/ParseInterval.java
@@ -31,14 +31,14 @@ import org.supercsv.util.CsvContext;
 public class ParseInterval extends CellProcessorAdaptor implements StringCellProcessor {
 
 	/**
-	 * Constructs a new <tt>ParseInterval</tt> processor, which parses a String
+	 * Constructs a new <code>ParseInterval</code> processor, which parses a String
 	 * as a Joda Interval.
 	 */
 	public ParseInterval() {
 	}
 
 	/**
-	 * Constructs a new <tt>ParseInterval</tt> processor, which parses a String
+	 * Constructs a new <code>ParseInterval</code> processor, which parses a String
 	 * as a Joda Interval, then calls the next processor in the chain.
 	 * 
 	 * @param next

--- a/super-csv-joda/src/main/java/org/supercsv/cellprocessor/joda/ParseLocalDate.java
+++ b/super-csv-joda/src/main/java/org/supercsv/cellprocessor/joda/ParseLocalDate.java
@@ -44,14 +44,14 @@ import org.supercsv.cellprocessor.ift.CellProcessor;
 public class ParseLocalDate extends AbstractJodaParsingProcessor<LocalDate> {
 
 	/**
-	 * Constructs a new <tt>ParseLocalDate</tt> processor, which parses a String
+	 * Constructs a new <code>ParseLocalDate</code> processor, which parses a String
 	 * as a Joda LocalDate.
 	 */
 	public ParseLocalDate() {
 	}
 
 	/**
-	 * Constructs a new <tt>ParseLocalDate</tt> processor, which parses a String
+	 * Constructs a new <code>ParseLocalDate</code> processor, which parses a String
 	 * as a Joda LocalDate, then calls the next processor in the chain.
 	 * 
 	 * @param next
@@ -64,7 +64,7 @@ public class ParseLocalDate extends AbstractJodaParsingProcessor<LocalDate> {
 	}
 
 	/**
-	 * Constructs a new <tt>ParseLocalDate</tt> processor, which parses a String
+	 * Constructs a new <code>ParseLocalDate</code> processor, which parses a String
 	 * as a Joda LocalDate using the supplied formatter.
 	 * 
 	 * @param formatter
@@ -77,7 +77,7 @@ public class ParseLocalDate extends AbstractJodaParsingProcessor<LocalDate> {
 	}
 
 	/**
-	 * Constructs a new <tt>ParseLocalDate</tt> processor, which parses a String
+	 * Constructs a new <code>ParseLocalDate</code> processor, which parses a String
 	 * as a Joda LocalDate using the supplied formatter, then calls the next
 	 * processor in the chain.
 	 * 

--- a/super-csv-joda/src/main/java/org/supercsv/cellprocessor/joda/ParseLocalDateTime.java
+++ b/super-csv-joda/src/main/java/org/supercsv/cellprocessor/joda/ParseLocalDateTime.java
@@ -45,14 +45,14 @@ public class ParseLocalDateTime extends
 		AbstractJodaParsingProcessor<LocalDateTime> {
 
 	/**
-	 * Constructs a new <tt>ParseLocalDateTime</tt> processor, which parses a
+	 * Constructs a new <code>ParseLocalDateTime</code> processor, which parses a
 	 * String as a Joda LocalDateTime.
 	 */
 	public ParseLocalDateTime() {
 	}
 
 	/**
-	 * Constructs a new <tt>ParseLocalDateTime</tt> processor, which parses a
+	 * Constructs a new <code>ParseLocalDateTime</code> processor, which parses a
 	 * String as a Joda LocalDateTime, then calls the next processor in the
 	 * chain.
 	 * 
@@ -66,7 +66,7 @@ public class ParseLocalDateTime extends
 	}
 
 	/**
-	 * Constructs a new <tt>ParseLocalDateTime</tt> processor, which parses a
+	 * Constructs a new <code>ParseLocalDateTime</code> processor, which parses a
 	 * String as a Joda LocalDateTime using the supplied formatter.
 	 * 
 	 * @param formatter
@@ -79,7 +79,7 @@ public class ParseLocalDateTime extends
 	}
 
 	/**
-	 * Constructs a new <tt>ParseLocalDateTime</tt> processor, which parses a
+	 * Constructs a new <code>ParseLocalDateTime</code> processor, which parses a
 	 * String as a Joda LocalDateTime using the supplied formatter, then calls
 	 * the next processor in the chain.
 	 * 

--- a/super-csv-joda/src/main/java/org/supercsv/cellprocessor/joda/ParseLocalTime.java
+++ b/super-csv-joda/src/main/java/org/supercsv/cellprocessor/joda/ParseLocalTime.java
@@ -45,14 +45,14 @@ public class ParseLocalTime extends
 		AbstractJodaParsingProcessor<LocalTime> {
 
 	/**
-	 * Constructs a new <tt>ParseLocalTime</tt> processor, which parses a
+	 * Constructs a new <code>ParseLocalTime</code> processor, which parses a
 	 * String as a Joda LocalTime.
 	 */
 	public ParseLocalTime() {
 	}
 
 	/**
-	 * Constructs a new <tt>ParseLocalTime</tt> processor, which parses a
+	 * Constructs a new <code>ParseLocalTime</code> processor, which parses a
 	 * String as a Joda LocalTime, then calls the next processor in the
 	 * chain.
 	 * 
@@ -66,7 +66,7 @@ public class ParseLocalTime extends
 	}
 
 	/**
-	 * Constructs a new <tt>ParseLocalTime</tt> processor, which parses a
+	 * Constructs a new <code>ParseLocalTime</code> processor, which parses a
 	 * String as a Joda LocalTime using the supplied formatter.
 	 * 
 	 * @param formatter
@@ -79,7 +79,7 @@ public class ParseLocalTime extends
 	}
 
 	/**
-	 * Constructs a new <tt>ParseLocalTime</tt> processor, which parses a
+	 * Constructs a new <code>ParseLocalTime</code> processor, which parses a
 	 * String as a Joda LocalTime using the supplied formatter, then calls
 	 * the next processor in the chain.
 	 * 

--- a/super-csv-joda/src/main/java/org/supercsv/cellprocessor/joda/ParsePeriod.java
+++ b/super-csv-joda/src/main/java/org/supercsv/cellprocessor/joda/ParsePeriod.java
@@ -51,7 +51,7 @@ public class ParsePeriod extends CellProcessorAdaptor implements StringCellProce
 	private final PeriodFormatter formatter;
 
 	/**
-	 * Constructs a new <tt>ParsePeriod</tt> processor, which parses a String as
+	 * Constructs a new <code>ParsePeriod</code> processor, which parses a String as
 	 * a Joda Period.
 	 */
 	public ParsePeriod() {
@@ -59,7 +59,7 @@ public class ParsePeriod extends CellProcessorAdaptor implements StringCellProce
 	}
 
 	/**
-	 * Constructs a new <tt>ParsePeriod</tt> processor, which parses a String as
+	 * Constructs a new <code>ParsePeriod</code> processor, which parses a String as
 	 * a Joda Period, then calls the next processor in the chain.
 	 * 
 	 * @param next
@@ -73,7 +73,7 @@ public class ParsePeriod extends CellProcessorAdaptor implements StringCellProce
 	}
 
 	/**
-	 * Constructs a new <tt>ParsePeriod</tt> processor, which parses a String as
+	 * Constructs a new <code>ParsePeriod</code> processor, which parses a String as
 	 * a Joda Period using the supplied formatter.
 	 * 
 	 * @param formatter
@@ -87,7 +87,7 @@ public class ParsePeriod extends CellProcessorAdaptor implements StringCellProce
 	}
 
 	/**
-	 * Constructs a new <tt>ParsePeriod</tt> processor, which parses a String as
+	 * Constructs a new <code>ParsePeriod</code> processor, which parses a String as
 	 * a Joda Period using the supplied formatter, then calls the next processor
 	 * in the chain.
 	 * 

--- a/super-csv-joda/src/main/java/org/supercsv/cellprocessor/joda/package-info.java
+++ b/super-csv-joda/src/main/java/org/supercsv/cellprocessor/joda/package-info.java
@@ -14,6 +14,6 @@
  * limitations under the License.
  */
 /**
- * Provides <tt>CellProcessor</tt> classes for formatting and parsing Joda-Time classes.
+ * Provides <code>CellProcessor</code> classes for formatting and parsing Joda-Time classes.
  */
 package org.supercsv.cellprocessor.joda;

--- a/super-csv-joda/src/test/java/org/supercsv/cellprocessor/joda/mock/IdentityTransform.java
+++ b/super-csv-joda/src/test/java/org/supercsv/cellprocessor/joda/mock/IdentityTransform.java
@@ -33,14 +33,14 @@ public class IdentityTransform extends CellProcessorAdaptor implements BoolCellP
 	DoubleCellProcessor, LongCellProcessor, StringCellProcessor {
 	
 	/**
-	 * Constructs a new <tt>IdentityTransform</tt> processor, which simply returns whatever is passed into it.
+	 * Constructs a new <code>IdentityTransform</code> processor, which simply returns whatever is passed into it.
 	 */
 	public IdentityTransform() {
 		super();
 	}
 	
 	/**
-	 * Constructs a new <tt>IdentityTransform</tt> processor which just calls the next processor in the chain.
+	 * Constructs a new <code>IdentityTransform</code> processor which just calls the next processor in the chain.
 	 * 
 	 * @param next
 	 *            the next processor in the chain

--- a/super-csv/src/main/java/org/supercsv/cellprocessor/CellProcessorAdaptor.java
+++ b/super-csv/src/main/java/org/supercsv/cellprocessor/CellProcessorAdaptor.java
@@ -26,7 +26,7 @@ import org.supercsv.util.CsvContext;
 
 /**
  * Abstract super class containing shared behaviour of all cell processors. Processors are linked together in a linked
- * list. The end element of this list should always be an instance of <tt>NullObjectPattern</tt>.
+ * list. The end element of this list should always be an instance of <code>NullObjectPattern</code>.
  * 
  * @author Kasper B. Graversen
  * @author James Bassett
@@ -45,10 +45,10 @@ public abstract class CellProcessorAdaptor implements CellProcessor {
 	}
 	
 	/**
-	 * Constructor used by CellProcessors that require <tt>CellProcessor</tt> chaining (further processing is required).
+	 * Constructor used by CellProcessors that require <code>CellProcessor</code> chaining (further processing is required).
 	 * 
 	 * @param next
-	 *            the next <tt>CellProcessor</tt> in the chain
+	 *            the next <code>CellProcessor</code> in the chain
 	 * @throws NullPointerException
 	 *             if next is null
 	 */
@@ -61,8 +61,8 @@ public abstract class CellProcessorAdaptor implements CellProcessor {
 	}
 	
 	/**
-	 * Checks that the input value is not <tt>null</tt>, throwing a <tt>NullInputException</tt> if it is. This method
-	 * should be called by all processors that need to ensure the input is not <tt>null</tt>.
+	 * Checks that the input value is not <code>null</code>, throwing a <code>NullInputException</code> if it is. This method
+	 * should be called by all processors that need to ensure the input is not <code>null</code>.
 	 * 
 	 * @param value
 	 *            the input value
@@ -89,9 +89,9 @@ public abstract class CellProcessorAdaptor implements CellProcessor {
 	}
 	
 	/**
-	 * This is an implementation-specific processor and should only be used by the <tt>CellProcessorAdaptor</tt> class.
+	 * This is an implementation-specific processor and should only be used by the <code>CellProcessorAdaptor</code> class.
 	 * It is the implementation of the null object pattern (it does nothing - just returns the value!) and should always
-	 * be the last <tt>CellProcessor</tt> in the chain. It is implemented as a reusable singleton to avoid unnecessary
+	 * be the last <code>CellProcessor</code> in the chain. It is implemented as a reusable singleton to avoid unnecessary
 	 * object creation.
 	 * 
 	 * @author Kasper B. Graversen

--- a/super-csv/src/main/java/org/supercsv/cellprocessor/Collector.java
+++ b/super-csv/src/main/java/org/supercsv/cellprocessor/Collector.java
@@ -39,7 +39,7 @@ public class Collector extends CellProcessorAdaptor implements BoolCellProcessor
 	private final Collection<Object> collection;
 	
 	/**
-	 * Constructs a new <tt>Collector</tt>, which collects each value it encounters and adds it to the supplied
+	 * Constructs a new <code>Collector</code>, which collects each value it encounters and adds it to the supplied
 	 * Collection.
 	 * 
 	 * @param collection
@@ -54,7 +54,7 @@ public class Collector extends CellProcessorAdaptor implements BoolCellProcessor
 	}
 	
 	/**
-	 * Constructs a new <tt>Collector</tt>, which collects each value it encounters, adds it to the supplied Collection,
+	 * Constructs a new <code>Collector</code>, which collects each value it encounters, adds it to the supplied Collection,
 	 * then calls the next processor in the chain.
 	 * 
 	 * @param collection

--- a/super-csv/src/main/java/org/supercsv/cellprocessor/ConvertNullTo.java
+++ b/super-csv/src/main/java/org/supercsv/cellprocessor/ConvertNullTo.java
@@ -24,14 +24,14 @@ import org.supercsv.cellprocessor.ift.StringCellProcessor;
 import org.supercsv.util.CsvContext;
 
 /**
- * This processor returns a specified default value if the input is <tt>null</tt>. This is handy when writing partially
+ * This processor returns a specified default value if the input is <code>null</code>. This is handy when writing partially
  * filled beans, maps and arrays, as for each column a default value can be specified.
  * <p>
- * To return the String <tt>""</tt> when a null is encountered use <code>
+ * To return the String <code>""</code> when a null is encountered use <code>
  * new ConvertNullTo("\"\"");
  * </code>
  * <p>
- * If you need further processing of the value in case the value is not <tt>null</tt>, you can link the processor with
+ * If you need further processing of the value in case the value is not <code>null</code>, you can link the processor with
  * other processors such as <code>
  * new ConvertNullTo("\"\"", new Truncate(3))
  * </code>
@@ -45,11 +45,11 @@ public class ConvertNullTo extends CellProcessorAdaptor implements BoolCellProce
 	private final Object returnValue;
 	
 	/**
-	 * Constructs a new <tt>ConvertNullTo</tt> processor, which returns a specified default value if the input is
-	 * <tt>null</tt>.
+	 * Constructs a new <code>ConvertNullTo</code> processor, which returns a specified default value if the input is
+	 * <code>null</code>.
 	 * 
 	 * @param returnValue
-	 *            the value to return if the input is <tt>null</tt>
+	 *            the value to return if the input is <code>null</code>
 	 */
 	public ConvertNullTo(final Object returnValue) {
 		super();
@@ -57,13 +57,13 @@ public class ConvertNullTo extends CellProcessorAdaptor implements BoolCellProce
 	}
 	
 	/**
-	 * Constructs a new <tt>ConvertNullTo</tt> processor, which returns a specified default value if the input is
-	 * <tt>null</tt>. If the input is not <tt>null</tt>, then the next processor is executed.
+	 * Constructs a new <code>ConvertNullTo</code> processor, which returns a specified default value if the input is
+	 * <code>null</code>. If the input is not <code>null</code>, then the next processor is executed.
 	 * 
 	 * @param returnValue
-	 *            the value to return if the input is <tt>null</tt>
+	 *            the value to return if the input is <code>null</code>
 	 * @param next
-	 *            the next <tt>CellProcessor</tt> in the chain
+	 *            the next <code>CellProcessor</code> in the chain
 	 * @throws NullPointerException
 	 *             if next is null
 	 */

--- a/super-csv/src/main/java/org/supercsv/cellprocessor/FmtBool.java
+++ b/super-csv/src/main/java/org/supercsv/cellprocessor/FmtBool.java
@@ -33,7 +33,7 @@ public class FmtBool extends CellProcessorAdaptor implements BoolCellProcessor {
 	private final String falseValue;
 	
 	/**
-	 * Constructs a new <tt>FmtBool</tt> processor, which converts a Boolean into a formatted string.
+	 * Constructs a new <code>FmtBool</code> processor, which converts a Boolean into a formatted string.
 	 * 
 	 * @param trueValue
 	 *            the String to use if the value is true
@@ -47,7 +47,7 @@ public class FmtBool extends CellProcessorAdaptor implements BoolCellProcessor {
 	}
 	
 	/**
-	 * Constructs a new <tt>FmtBool</tt> processor, which converts a Boolean into a formatted string, then calls the
+	 * Constructs a new <code>FmtBool</code> processor, which converts a Boolean into a formatted string, then calls the
 	 * next processor in the chain.
 	 * 
 	 * @param trueValue

--- a/super-csv/src/main/java/org/supercsv/cellprocessor/FmtDate.java
+++ b/super-csv/src/main/java/org/supercsv/cellprocessor/FmtDate.java
@@ -42,7 +42,7 @@ public class FmtDate extends CellProcessorAdaptor implements DateCellProcessor {
 	private final String dateFormat;
 	
 	/**
-	 * Constructs a new <tt>FmtDate</tt> processor, which converts a date into a formatted string using
+	 * Constructs a new <code>FmtDate</code> processor, which converts a date into a formatted string using
 	 * SimpleDateFormat.
 	 * 
 	 * @param dateFormat
@@ -57,7 +57,7 @@ public class FmtDate extends CellProcessorAdaptor implements DateCellProcessor {
 	}
 	
 	/**
-	 * Constructs a new <tt>FmtDate</tt> processor, which converts a date into a formatted string using
+	 * Constructs a new <code>FmtDate</code> processor, which converts a date into a formatted string using
 	 * SimpleDateFormat, then calls the next processor in the chain.
 	 * 
 	 * @param dateFormat

--- a/super-csv/src/main/java/org/supercsv/cellprocessor/FmtNumber.java
+++ b/super-csv/src/main/java/org/supercsv/cellprocessor/FmtNumber.java
@@ -27,7 +27,7 @@ import org.supercsv.util.CsvContext;
  * Converts a double into a formatted string using the {@link DecimalFormat} class and the default locale. This is
  * useful, when you need to show numbers with a specific number of digits.
  * <p>
- * Please be aware that the constructors that use <tt>DecimalFormat</tt> are not thread-safe, so it is generally better
+ * Please be aware that the constructors that use <code>DecimalFormat</code> are not thread-safe, so it is generally better
  * to use the constructors that accept a date format String.
  * <p>
  * In the format string, the following characters are defined as : <br>
@@ -56,7 +56,7 @@ public class FmtNumber extends CellProcessorAdaptor implements DoubleCellProcess
 	private final DecimalFormat formatter;
 	
 	/**
-	 * Constructs a new <tt>FmtNumber</tt> processor, which converts a double into a formatted string using the supplied
+	 * Constructs a new <code>FmtNumber</code> processor, which converts a double into a formatted string using the supplied
 	 * decimal format String. This constructor is thread-safe.
 	 * 
 	 * @param decimalFormat
@@ -72,7 +72,7 @@ public class FmtNumber extends CellProcessorAdaptor implements DoubleCellProcess
 	}
 	
 	/**
-	 * Constructs a new <tt>FmtNumber</tt> processor, which converts a double into a formatted string using the supplied
+	 * Constructs a new <code>FmtNumber</code> processor, which converts a double into a formatted string using the supplied
 	 * decimal format String, then calls the next processor in the chain. This constructor is thread-safe.
 	 * 
 	 * @param decimalFormat
@@ -90,7 +90,7 @@ public class FmtNumber extends CellProcessorAdaptor implements DoubleCellProcess
 	}
 	
 	/**
-	 * Constructs a new <tt>FmtNumber</tt> processor, which converts a double into a formatted string using the supplied
+	 * Constructs a new <code>FmtNumber</code> processor, which converts a double into a formatted string using the supplied
 	 * decimal format. This constructor is not thread-safe.
 	 * 
 	 * @param formatter
@@ -106,7 +106,7 @@ public class FmtNumber extends CellProcessorAdaptor implements DoubleCellProcess
 	}
 	
 	/**
-	 * Constructs a new <tt>FmtNumber</tt> processor, which converts a double into a formatted string using the supplied
+	 * Constructs a new <code>FmtNumber</code> processor, which converts a double into a formatted string using the supplied
 	 * decimal format, then calls the next processor in the chain. This constructor is not thread-safe.
 	 * 
 	 * @param formatter

--- a/super-csv/src/main/java/org/supercsv/cellprocessor/FmtSqlTime.java
+++ b/super-csv/src/main/java/org/supercsv/cellprocessor/FmtSqlTime.java
@@ -40,7 +40,7 @@ public class FmtSqlTime extends CellProcessorAdaptor implements DateCellProcesso
 	private final String dateFormat;
 	
 	/**
-	 * Constructs a new <tt>FmtTime</tt> processor, which converts a time into a formatted string using
+	 * Constructs a new <code>FmtTime</code> processor, which converts a time into a formatted string using
 	 * SimpleDateFormat.
 	 * 
 	 * @param dateFormat
@@ -55,7 +55,7 @@ public class FmtSqlTime extends CellProcessorAdaptor implements DateCellProcesso
 	}
 	
 	/**
-	 * Constructs a new <tt>FmtTime</tt> processor, which converts a time into a formatted string using
+	 * Constructs a new <code>FmtTime</code> processor, which converts a time into a formatted string using
 	 * SimpleDateFormat, then calls the next processor in the chain.
 	 * 
 	 * @param dateFormat

--- a/super-csv/src/main/java/org/supercsv/cellprocessor/HashMapper.java
+++ b/super-csv/src/main/java/org/supercsv/cellprocessor/HashMapper.java
@@ -27,7 +27,7 @@ import org.supercsv.exception.SuperCsvCellProcessorException;
 import org.supercsv.util.CsvContext;
 
 /**
- * Maps from one object to another, by looking up a <tt>Map</tt> with the input as the key, and returning its
+ * Maps from one object to another, by looking up a <code>Map</code> with the input as the key, and returning its
  * corresponding value.
  * 
  * @since 1.50
@@ -41,9 +41,9 @@ public class HashMapper extends CellProcessorAdaptor implements BoolCellProcesso
 	private final Object defaultValue;
 	
 	/**
-	 * Constructs a new <tt>HashMapper</tt> processor, which maps from one object to another, by looking up a
-	 * <tt>Map</tt> with the input as the key, and returning its corresponding value. If no mapping is found, then
-	 * <tt>null</tt> is returned.
+	 * Constructs a new <code>HashMapper</code> processor, which maps from one object to another, by looking up a
+	 * <code>Map</code> with the input as the key, and returning its corresponding value. If no mapping is found, then
+	 * <code>null</code> is returned.
 	 * 
 	 * @param mapping
 	 *            the Map
@@ -57,8 +57,8 @@ public class HashMapper extends CellProcessorAdaptor implements BoolCellProcesso
 	}
 	
 	/**
-	 * Constructs a new <tt>HashMapper</tt> processor, which maps from one object to another, by looking up a
-	 * <tt>Map</tt> with the input as the key, and returning its corresponding value. If no mapping is found, then the
+	 * Constructs a new <code>HashMapper</code> processor, which maps from one object to another, by looking up a
+	 * <code>Map</code> with the input as the key, and returning its corresponding value. If no mapping is found, then the
 	 * supplied default value is returned.
 	 * 
 	 * @param mapping
@@ -79,9 +79,9 @@ public class HashMapper extends CellProcessorAdaptor implements BoolCellProcesso
 	}
 	
 	/**
-	 * Constructs a new <tt>HashMapper</tt> processor, which maps from one object to another, by looking up a
-	 * <tt>Map</tt> with the input as the key, and returning its corresponding value. If no mapping is found, then
-	 * <tt>null</tt> is returned. Regardless of whether a mapping is found, the next processor in the chain will be
+	 * Constructs a new <code>HashMapper</code> processor, which maps from one object to another, by looking up a
+	 * <code>Map</code> with the input as the key, and returning its corresponding value. If no mapping is found, then
+	 * <code>null</code> is returned. Regardless of whether a mapping is found, the next processor in the chain will be
 	 * called.
 	 * 
 	 * @param mapping
@@ -98,8 +98,8 @@ public class HashMapper extends CellProcessorAdaptor implements BoolCellProcesso
 	}
 	
 	/**
-	 * Constructs a new <tt>HashMapper</tt> processor, which maps from one object to another, by looking up a
-	 * <tt>Map</tt> with the input as the key, and returning its corresponding value. If no mapping is found, then the
+	 * Constructs a new <code>HashMapper</code> processor, which maps from one object to another, by looking up a
+	 * <code>Map</code> with the input as the key, and returning its corresponding value. If no mapping is found, then the
 	 * supplied default value is returned. Regardless of whether a mapping is found, the next processor in the chain
 	 * will be called.
 	 * 

--- a/super-csv/src/main/java/org/supercsv/cellprocessor/Optional.java
+++ b/super-csv/src/main/java/org/supercsv/cellprocessor/Optional.java
@@ -19,10 +19,10 @@ import org.supercsv.cellprocessor.ift.CellProcessor;
 
 /**
  * This processor is used to indicate that a cell is optional, and will avoid executing further processors if it
- * encounters <tt>null</tt>. It is a simple customization of <tt>ConvertNullTo</tt>.
+ * encounters <code>null</code>. It is a simple customization of <code>ConvertNullTo</code>.
  * <p>
- * Prior to version 2.0.0, this processor returned <tt>null</tt> for empty String (""), but was updated because
- * Tokenizer now reads empty columns as <tt>null</tt>. It also means that Optional can now be used when writing as well
+ * Prior to version 2.0.0, this processor returned <code>null</code> for empty String (""), but was updated because
+ * Tokenizer now reads empty columns as <code>null</code>. It also means that Optional can now be used when writing as well
  * (instead of using {@code ConvertNullTo("")}).
  * 
  * @author Kasper B. Graversen
@@ -31,7 +31,7 @@ import org.supercsv.cellprocessor.ift.CellProcessor;
 public class Optional extends ConvertNullTo {
 	
 	/**
-	 * Constructs a new <tt>Optional</tt> processor, which when encountering <tt>null</tt> will return <tt>null</tt>,
+	 * Constructs a new <code>Optional</code> processor, which when encountering <code>null</code> will return <code>null</code>,
 	 * for all other values it will return the value unchanged.
 	 */
 	public Optional() {
@@ -39,7 +39,7 @@ public class Optional extends ConvertNullTo {
 	}
 	
 	/**
-	 * Constructs a new <tt>Optional</tt> processor, which when encountering <tt>null</tt> will return <tt>null</tt> ,
+	 * Constructs a new <code>Optional</code> processor, which when encountering <code>null</code> will return <code>null</code> ,
 	 * for all other values it will call the next processor in the chain.
 	 * 
 	 * @param next

--- a/super-csv/src/main/java/org/supercsv/cellprocessor/ParseBigDecimal.java
+++ b/super-csv/src/main/java/org/supercsv/cellprocessor/ParseBigDecimal.java
@@ -24,13 +24,13 @@ import org.supercsv.exception.SuperCsvCellProcessorException;
 import org.supercsv.util.CsvContext;
 
 /**
- * Convert a String to a BigDecimal. It uses the String constructor of BigDecimal (<tt>new BigDecimal("0.1")</tt>) as it
+ * Convert a String to a BigDecimal. It uses the String constructor of BigDecimal (<code>new BigDecimal("0.1")</code>) as it
  * yields predictable results (see {@link BigDecimal}).
  * <p>
  * If the data uses a character other than "." as a decimal separator (Germany uses "," for example), then use the
- * constructor that accepts a <tt>DecimalFormatSymbols</tt> object, as it will convert the character to a "." before
+ * constructor that accepts a <code>DecimalFormatSymbols</code> object, as it will convert the character to a "." before
  * creating the BigDecimal. Likewise if the data contains a grouping separator (Germany uses "." for example) then
- * supplying a <tt>DecimalFormatSymbols</tt> object will allow grouping separators to be removed before parsing.
+ * supplying a <code>DecimalFormatSymbols</code> object will allow grouping separators to be removed before parsing.
  * 
  * @since 1.30
  * @author Kasper B. Graversen
@@ -43,15 +43,15 @@ public class ParseBigDecimal extends CellProcessorAdaptor implements StringCellP
 	private final DecimalFormatSymbols symbols;
 	
 	/**
-	 * Constructs a new <tt>ParseBigDecimal</tt> processor, which converts a String to a BigDecimal.
+	 * Constructs a new <code>ParseBigDecimal</code> processor, which converts a String to a BigDecimal.
 	 */
 	public ParseBigDecimal() {
 		this.symbols = null;
 	}
 	
 	/**
-	 * Constructs a new <tt>ParseBigDecimal</tt> processor, which converts a String to a BigDecimal using the supplied
-	 * <tt>DecimalFormatSymbols</tt> object to convert any decimal separator to a "." before creating the BigDecimal.
+	 * Constructs a new <code>ParseBigDecimal</code> processor, which converts a String to a BigDecimal using the supplied
+	 * <code>DecimalFormatSymbols</code> object to convert any decimal separator to a "." before creating the BigDecimal.
 	 * 
 	 * @param symbols
 	 *            the decimal format symbols, containing the decimal separator
@@ -65,7 +65,7 @@ public class ParseBigDecimal extends CellProcessorAdaptor implements StringCellP
 	}
 	
 	/**
-	 * Constructs a new <tt>ParseBigDecimal</tt> processor, which converts a String to a BigDecimal then calls the next
+	 * Constructs a new <code>ParseBigDecimal</code> processor, which converts a String to a BigDecimal then calls the next
 	 * processor in the chain.
 	 * 
 	 * @param next
@@ -79,8 +79,8 @@ public class ParseBigDecimal extends CellProcessorAdaptor implements StringCellP
 	}
 	
 	/**
-	 * Constructs a new <tt>ParseBigDecimal</tt> processor, which converts a String to a BigDecimal using the supplied
-	 * <tt>DecimalFormatSymbols</tt> object to convert any decimal separator to a "." before creating the BigDecimal,
+	 * Constructs a new <code>ParseBigDecimal</code> processor, which converts a String to a BigDecimal using the supplied
+	 * <code>DecimalFormatSymbols</code> object to convert any decimal separator to a "." before creating the BigDecimal,
 	 * then calls the next processor in the chain.
 	 * 
 	 * @param symbols

--- a/super-csv/src/main/java/org/supercsv/cellprocessor/ParseBool.java
+++ b/super-csv/src/main/java/org/supercsv/cellprocessor/ParseBool.java
@@ -27,17 +27,17 @@ import org.supercsv.util.CsvContext;
 /**
  * Converts a String to a Boolean.
  * <p>
- * The default values for true are: <tt>"true", "1", "y", "t"</tt>
+ * The default values for true are: <code>"true", "1", "y", "t"</code>
  * <p>
- * The default values for false are: <tt>"false", "0", "n", "f"</tt>
+ * The default values for false are: <code>"false", "0", "n", "f"</code>
  * <p>
- * By default (unless the <tt>ignoreCase</tt> parameter is supplied on the constructor) this processor will ignore the
- * case of the value, i.e. "true", "TRUE", and "True" will all be converted to <tt>true</tt> (likewise for
- * <tt>false</tt>).
+ * By default (unless the <code>ignoreCase</code> parameter is supplied on the constructor) this processor will ignore the
+ * case of the value, i.e. "true", "TRUE", and "True" will all be converted to <code>true</code> (likewise for
+ * <code>false</code>).
  * <p>
  * Prior to version 2.2.1, this processor always ignored case, so it was necessary to ensure that all supplied
  * true/false values were lowercase, as the input was converted to lowercase before comparison against the true/false
- * values (to handle all variations of case in the input). This is no longer required (just use the <tt>ignoreCase</tt>
+ * values (to handle all variations of case in the input). This is no longer required (just use the <code>ignoreCase</code>
  * parameter).
  * 
  * @author Kasper B. Graversen
@@ -56,7 +56,7 @@ public class ParseBool extends CellProcessorAdaptor implements StringCellProcess
 	private final boolean ignoreCase;
 	
 	/**
-	 * Constructs a new <tt>ParseBool</tt> processor, which converts a String to a Boolean using the default values
+	 * Constructs a new <code>ParseBool</code> processor, which converts a String to a Boolean using the default values
 	 * (ignoring case).
 	 */
 	public ParseBool() {
@@ -64,7 +64,7 @@ public class ParseBool extends CellProcessorAdaptor implements StringCellProcess
 	}
 	
 	/**
-	 * Constructs a new <tt>ParseBool</tt> processor, which converts a String to a Boolean using the default values
+	 * Constructs a new <code>ParseBool</code> processor, which converts a String to a Boolean using the default values
 	 * (ignoring case if desired).
 	 * 
 	 * @since 2.2.1
@@ -76,7 +76,7 @@ public class ParseBool extends CellProcessorAdaptor implements StringCellProcess
 	}
 	
 	/**
-	 * Constructs a new <tt>ParseBool</tt> processor, which converts a String to a Boolean using the default values
+	 * Constructs a new <code>ParseBool</code> processor, which converts a String to a Boolean using the default values
 	 * (ignoring case), then calls the next processor in the chain.
 	 * 
 	 * @param next
@@ -89,7 +89,7 @@ public class ParseBool extends CellProcessorAdaptor implements StringCellProcess
 	}
 	
 	/**
-	 * Constructs a new <tt>ParseBool</tt> processor, which converts a String to a Boolean using the default values
+	 * Constructs a new <code>ParseBool</code> processor, which converts a String to a Boolean using the default values
 	 * (ignoring case if desired), then calls the next processor in the chain.
 	 * 
 	 * @since 2.2.1
@@ -105,7 +105,7 @@ public class ParseBool extends CellProcessorAdaptor implements StringCellProcess
 	}
 	
 	/**
-	 * Constructs a new <tt>ParseBool</tt> processor, which converts a String to a Boolean using the supplied true/false
+	 * Constructs a new <code>ParseBool</code> processor, which converts a String to a Boolean using the supplied true/false
 	 * values (ignoring case).
 	 * 
 	 * @param trueValue
@@ -120,7 +120,7 @@ public class ParseBool extends CellProcessorAdaptor implements StringCellProcess
 	}
 	
 	/**
-	 * Constructs a new <tt>ParseBool</tt> processor, which converts a String to a Boolean using the supplied true/false
+	 * Constructs a new <code>ParseBool</code> processor, which converts a String to a Boolean using the supplied true/false
 	 * values (ignoring case if desired).
 	 * 
 	 * @since 2.2.1
@@ -142,7 +142,7 @@ public class ParseBool extends CellProcessorAdaptor implements StringCellProcess
 	}
 	
 	/**
-	 * Constructs a new <tt>ParseBool</tt> processor, which converts a String to a Boolean using the supplied true/false
+	 * Constructs a new <code>ParseBool</code> processor, which converts a String to a Boolean using the supplied true/false
 	 * values (ignoring case).
 	 * 
 	 * @param trueValues
@@ -159,7 +159,7 @@ public class ParseBool extends CellProcessorAdaptor implements StringCellProcess
 	}
 	
 	/**
-	 * Constructs a new <tt>ParseBool</tt> processor, which converts a String to a Boolean using the supplied true/false
+	 * Constructs a new <code>ParseBool</code> processor, which converts a String to a Boolean using the supplied true/false
 	 * values (ignoring case if desired).
 	 * 
 	 * @since 2.2.1
@@ -183,7 +183,7 @@ public class ParseBool extends CellProcessorAdaptor implements StringCellProcess
 	}
 	
 	/**
-	 * Constructs a new <tt>ParseBool</tt> processor, which converts a String to a Boolean using the supplied true/false
+	 * Constructs a new <code>ParseBool</code> processor, which converts a String to a Boolean using the supplied true/false
 	 * values (ignoring case), then calls the next processor in the chain.
 	 * 
 	 * @param trueValue
@@ -200,7 +200,7 @@ public class ParseBool extends CellProcessorAdaptor implements StringCellProcess
 	}
 	
 	/**
-	 * Constructs a new <tt>ParseBool</tt> processor, which converts a String to a Boolean using the supplied true/false
+	 * Constructs a new <code>ParseBool</code> processor, which converts a String to a Boolean using the supplied true/false
 	 * values (ignoring case if desired), then calls the next processor in the chain.
 	 * 
 	 * @since 2.2.1
@@ -225,7 +225,7 @@ public class ParseBool extends CellProcessorAdaptor implements StringCellProcess
 	}
 	
 	/**
-	 * Constructs a new <tt>ParseBool</tt> processor, which converts a String to a Boolean using the supplied true/false
+	 * Constructs a new <code>ParseBool</code> processor, which converts a String to a Boolean using the supplied true/false
 	 * values (ignoring case), then calls the next processor in the chain.
 	 * 
 	 * @param trueValues
@@ -244,7 +244,7 @@ public class ParseBool extends CellProcessorAdaptor implements StringCellProcess
 	}
 	
 	/**
-	 * Constructs a new <tt>ParseBool</tt> processor, which converts a String to a Boolean using the supplied true/false
+	 * Constructs a new <code>ParseBool</code> processor, which converts a String to a Boolean using the supplied true/false
 	 * values (ignoring case if desired), then calls the next processor in the chain.
 	 * 
 	 * @since 2.2.1

--- a/super-csv/src/main/java/org/supercsv/cellprocessor/ParseChar.java
+++ b/super-csv/src/main/java/org/supercsv/cellprocessor/ParseChar.java
@@ -29,14 +29,14 @@ import org.supercsv.util.CsvContext;
 public class ParseChar extends CellProcessorAdaptor implements StringCellProcessor {
 	
 	/**
-	 * Constructs a new <tt>ParseChar</tt> processor, which converts a String to a Character.
+	 * Constructs a new <code>ParseChar</code> processor, which converts a String to a Character.
 	 */
 	public ParseChar() {
 		super();
 	}
 	
 	/**
-	 * Constructs a new <tt>ParseChar</tt> processor, which converts a String to a Character, then calls the next
+	 * Constructs a new <code>ParseChar</code> processor, which converts a String to a Character, then calls the next
 	 * processor in the chain.
 	 * 
 	 * @param next

--- a/super-csv/src/main/java/org/supercsv/cellprocessor/ParseDateTimeAbstract.java
+++ b/super-csv/src/main/java/org/supercsv/cellprocessor/ParseDateTimeAbstract.java
@@ -56,7 +56,7 @@ public abstract class ParseDateTimeAbstract extends CellProcessorAdaptor impleme
 	protected SimpleDateFormat formatter;
 	
 	/**
-	 * Constructs a new <tt>ParseDateTimeAbstract</tt> processor which converts a String to a Date/Time using the
+	 * Constructs a new <code>ParseDateTimeAbstract</code> processor which converts a String to a Date/Time using the
 	 * supplied date format. This constructor uses non-lenient Date interpretation.
 	 * 
 	 * @param dateFormat
@@ -69,7 +69,7 @@ public abstract class ParseDateTimeAbstract extends CellProcessorAdaptor impleme
 	}
 	
 	/**
-	 * Constructs a new <tt>ParseDateTimeAbstract</tt> processor which converts a String to a Date/Time using the
+	 * Constructs a new <code>ParseDateTimeAbstract</code> processor which converts a String to a Date/Time using the
 	 * supplied date format.
 	 * 
 	 * @param dateFormat
@@ -88,7 +88,7 @@ public abstract class ParseDateTimeAbstract extends CellProcessorAdaptor impleme
 	}
 	
 	/**
-	 * Constructs a new <tt>ParseDateTimeAbstract</tt> processor which converts a String to a Date/Time using the
+	 * Constructs a new <code>ParseDateTimeAbstract</code> processor which converts a String to a Date/Time using the
 	 * supplied date format and Locale.
 	 * 
 	 * @param dateFormat
@@ -109,7 +109,7 @@ public abstract class ParseDateTimeAbstract extends CellProcessorAdaptor impleme
 	}
 	
 	/**
-	 * Constructs a new <tt>ParseDateTimeAbstract</tt> processor which converts a String to a Date/Time using the
+	 * Constructs a new <code>ParseDateTimeAbstract</code> processor which converts a String to a Date/Time using the
 	 * supplied date format, then calls the next processor in the chain. This constructor uses non-lenient Date
 	 * interpretation.
 	 * 
@@ -125,7 +125,7 @@ public abstract class ParseDateTimeAbstract extends CellProcessorAdaptor impleme
 	}
 	
 	/**
-	 * Constructs a new <tt>ParseDateTimeAbstract</tt> processor which converts a String to a Date/Time using the
+	 * Constructs a new <code>ParseDateTimeAbstract</code> processor which converts a String to a Date/Time using the
 	 * supplied date format, then calls the next processor in the chain.
 	 * 
 	 * @param dateFormat
@@ -146,7 +146,7 @@ public abstract class ParseDateTimeAbstract extends CellProcessorAdaptor impleme
 	}
 	
 	/**
-	 * Constructs a new <tt>ParseDateTimeAbstract</tt> processor which converts a String to a Date/Time using the
+	 * Constructs a new <code>ParseDateTimeAbstract</code> processor which converts a String to a Date/Time using the
 	 * supplied date format and Locale, then calls the next processor in the chain.
 	 * 
 	 * @param dateFormat

--- a/super-csv/src/main/java/org/supercsv/cellprocessor/ParseDouble.java
+++ b/super-csv/src/main/java/org/supercsv/cellprocessor/ParseDouble.java
@@ -28,14 +28,14 @@ import org.supercsv.util.CsvContext;
 public class ParseDouble extends CellProcessorAdaptor implements StringCellProcessor {
 	
 	/**
-	 * Constructs a new <tt>ParseDouble</tt> processor, which converts a String to a Double.
+	 * Constructs a new <code>ParseDouble</code> processor, which converts a String to a Double.
 	 */
 	public ParseDouble() {
 		super();
 	}
 	
 	/**
-	 * Constructs a new <tt>ParseDouble</tt> processor, which converts a String to a Double, then calls the next
+	 * Constructs a new <code>ParseDouble</code> processor, which converts a String to a Double, then calls the next
 	 * processor in the chain.
 	 * 
 	 * @param next

--- a/super-csv/src/main/java/org/supercsv/cellprocessor/ParseEnum.java
+++ b/super-csv/src/main/java/org/supercsv/cellprocessor/ParseEnum.java
@@ -33,7 +33,7 @@ public class ParseEnum extends CellProcessorAdaptor implements StringCellProcess
 	private final boolean ignoreCase;
 	
 	/**
-	 * Constructs a new <tt>ParseEnum</tt> processor, which converts a String to a Enum.
+	 * Constructs a new <code>ParseEnum</code> processor, which converts a String to a Enum.
 	 * 
 	 * @param enumClass
 	 *            the enum class to convert to
@@ -50,7 +50,7 @@ public class ParseEnum extends CellProcessorAdaptor implements StringCellProcess
 	}
 	
 	/**
-	 * Constructs a new <tt>ParseEnum</tt> processor, which converts a String to a Enum, ignoring the case of the input
+	 * Constructs a new <code>ParseEnum</code> processor, which converts a String to a Enum, ignoring the case of the input
 	 * (or not) depending on the supplied flag.
 	 * 
 	 * @param enumClass
@@ -70,7 +70,7 @@ public class ParseEnum extends CellProcessorAdaptor implements StringCellProcess
 	}
 	
 	/**
-	 * Constructs a new <tt>ParseEnum</tt> processor, which converts a String to a Enum then calls the next processor in
+	 * Constructs a new <code>ParseEnum</code> processor, which converts a String to a Enum then calls the next processor in
 	 * the chain.
 	 * 
 	 * @param enumClass
@@ -90,7 +90,7 @@ public class ParseEnum extends CellProcessorAdaptor implements StringCellProcess
 	}
 	
 	/**
-	 * Constructs a new <tt>ParseEnum</tt> processor, which converts a String to a Enum, ignoring the case of the input
+	 * Constructs a new <code>ParseEnum</code> processor, which converts a String to a Enum, ignoring the case of the input
 	 * (or not) depending on the supplied flag, then calls the next processor in the chain.
 	 * 
 	 * @param enumClass

--- a/super-csv/src/main/java/org/supercsv/cellprocessor/ParseInt.java
+++ b/super-csv/src/main/java/org/supercsv/cellprocessor/ParseInt.java
@@ -28,14 +28,14 @@ import org.supercsv.util.CsvContext;
 public class ParseInt extends CellProcessorAdaptor implements StringCellProcessor {
 	
 	/**
-	 * Constructs a new <tt>ParseInt</tt> processor, which converts a String to an Integer.
+	 * Constructs a new <code>ParseInt</code> processor, which converts a String to an Integer.
 	 */
 	public ParseInt() {
 		super();
 	}
 	
 	/**
-	 * Constructs a new <tt>ParseInt</tt> processor, which converts a String to an Integer, then calls the next
+	 * Constructs a new <code>ParseInt</code> processor, which converts a String to an Integer, then calls the next
 	 * processor in the chain.
 	 * 
 	 * @param next

--- a/super-csv/src/main/java/org/supercsv/cellprocessor/ParseLong.java
+++ b/super-csv/src/main/java/org/supercsv/cellprocessor/ParseLong.java
@@ -28,14 +28,14 @@ import org.supercsv.util.CsvContext;
 public class ParseLong extends CellProcessorAdaptor implements StringCellProcessor {
 	
 	/**
-	 * Constructs a new <tt>ParseLong</tt> processor, which converts a String to a Long.
+	 * Constructs a new <code>ParseLong</code> processor, which converts a String to a Long.
 	 */
 	public ParseLong() {
 		super();
 	}
 	
 	/**
-	 * Constructs a new <tt>ParseLong</tt> processor, which converts a String to a Long, then calls the next processor
+	 * Constructs a new <code>ParseLong</code> processor, which converts a String to a Long, then calls the next processor
 	 * in the chain.
 	 * 
 	 * @param next

--- a/super-csv/src/main/java/org/supercsv/cellprocessor/StrReplace.java
+++ b/super-csv/src/main/java/org/supercsv/cellprocessor/StrReplace.java
@@ -41,7 +41,7 @@ public class StrReplace extends CellProcessorAdaptor implements BoolCellProcesso
 	private final String replacement;
 	
 	/**
-	 * Constructs a new <tt>StrReplace</tt> processor, which replaces each substring of the input that matches the regex
+	 * Constructs a new <code>StrReplace</code> processor, which replaces each substring of the input that matches the regex
 	 * with the supplied replacement.
 	 * 
 	 * @param regex
@@ -63,7 +63,7 @@ public class StrReplace extends CellProcessorAdaptor implements BoolCellProcesso
 	}
 	
 	/**
-	 * Constructs a new <tt>StrReplace</tt> processor, which replaces each substring of the input that matches the regex
+	 * Constructs a new <code>StrReplace</code> processor, which replaces each substring of the input that matches the regex
 	 * with the supplied replacement, then calls the next processor in the chain.
 	 * 
 	 * @param regex

--- a/super-csv/src/main/java/org/supercsv/cellprocessor/Token.java
+++ b/super-csv/src/main/java/org/supercsv/cellprocessor/Token.java
@@ -29,11 +29,11 @@ import org.supercsv.util.CsvContext;
  * token". Such a token could be the string "[empty]" which could denote that a column is different from the empty
  * string "".
  * <p>
- * For example, to convert the String <tt>"[empty]"</tt> to -1 (an int representing 'empty') you could use <code>
+ * For example, to convert the String <code>"[empty]"</code> to -1 (an int representing 'empty') you could use <code>
  * new Token("[empty]", -1)
  * </code>
  * <p>
- * Comparison between the input and the <tt>token</tt> is based on the object's <tt>equals()</tt> method.
+ * Comparison between the input and the <code>token</code> is based on the object's <code>equals()</code> method.
  * 
  * @since 1.02
  * @author Kasper B. Graversen
@@ -45,7 +45,7 @@ public class Token extends CellProcessorAdaptor implements BoolCellProcessor, Da
 	private final Object token;
 	
 	/**
-	 * Constructs a new <tt>Token</tt> processor, which returns the supplied value if the token is encountered,
+	 * Constructs a new <code>Token</code> processor, which returns the supplied value if the token is encountered,
 	 * otherwise it returns the input unchanged.
 	 * 
 	 * @param token
@@ -60,7 +60,7 @@ public class Token extends CellProcessorAdaptor implements BoolCellProcessor, Da
 	}
 	
 	/**
-	 * Constructs a new <tt>Token</tt> processor, which returns the supplied value if the token is encountered,
+	 * Constructs a new <code>Token</code> processor, which returns the supplied value if the token is encountered,
 	 * otherwise it passes the input unchanged to the next processor in the chain.
 	 * 
 	 * @param token

--- a/super-csv/src/main/java/org/supercsv/cellprocessor/Trim.java
+++ b/super-csv/src/main/java/org/supercsv/cellprocessor/Trim.java
@@ -35,14 +35,14 @@ public class Trim extends CellProcessorAdaptor implements BoolCellProcessor, Dat
 	LongCellProcessor, StringCellProcessor {
 	
 	/**
-	 * Constructs a new <tt>Trim</tt> processor, which trims a String to ensure it has no surrounding whitespace.
+	 * Constructs a new <code>Trim</code> processor, which trims a String to ensure it has no surrounding whitespace.
 	 */
 	public Trim() {
 		super();
 	}
 	
 	/**
-	 * Constructs a new <tt>Trim</tt> processor, which trims a String to ensure it has no surrounding whitespace then
+	 * Constructs a new <code>Trim</code> processor, which trims a String to ensure it has no surrounding whitespace then
 	 * calls the next processor in the chain.
 	 * 
 	 * @param next

--- a/super-csv/src/main/java/org/supercsv/cellprocessor/Truncate.java
+++ b/super-csv/src/main/java/org/supercsv/cellprocessor/Truncate.java
@@ -42,7 +42,7 @@ public class Truncate extends CellProcessorAdaptor implements BoolCellProcessor,
 	private final String suffix;
 	
 	/**
-	 * Constructs a new <tt>Truncate</tt> processor, which truncates a String to ensure it is no longer than the
+	 * Constructs a new <code>Truncate</code> processor, which truncates a String to ensure it is no longer than the
 	 * specified size.
 	 * 
 	 * @param maxSize
@@ -55,7 +55,7 @@ public class Truncate extends CellProcessorAdaptor implements BoolCellProcessor,
 	}
 	
 	/**
-	 * Constructs a new <tt>Truncate</tt> processor, which truncates a String to ensure it is no longer than the
+	 * Constructs a new <code>Truncate</code> processor, which truncates a String to ensure it is no longer than the
 	 * specified size, then appends the <code>suffix</code> String to indicate that the String has been truncated.
 	 * 
 	 * @param maxSize
@@ -74,7 +74,7 @@ public class Truncate extends CellProcessorAdaptor implements BoolCellProcessor,
 	}
 	
 	/**
-	 * Constructs a new <tt>Truncate</tt> processor, which truncates a String to ensure it is no longer than the
+	 * Constructs a new <code>Truncate</code> processor, which truncates a String to ensure it is no longer than the
 	 * specified size, then appends the <code>suffix</code> String to indicate that the String has been truncated and
 	 * calls the next processor in the chain.
 	 * 
@@ -97,7 +97,7 @@ public class Truncate extends CellProcessorAdaptor implements BoolCellProcessor,
 	}
 	
 	/**
-	 * Constructs a new <tt>Truncate</tt> processor, which truncates a String to ensure it is no longer than the
+	 * Constructs a new <code>Truncate</code> processor, which truncates a String to ensure it is no longer than the
 	 * specified size, then calls the next processor in the chain.
 	 * 
 	 * @param maxSize

--- a/super-csv/src/main/java/org/supercsv/cellprocessor/constraint/DMinMax.java
+++ b/super-csv/src/main/java/org/supercsv/cellprocessor/constraint/DMinMax.java
@@ -67,7 +67,7 @@ public class DMinMax extends CellProcessorAdaptor implements StringCellProcessor
 	private final double max;
 	
 	/**
-	 * Constructs a new <tt>DMinMax</tt> processor, which converts the input to a Double and ensures the value is
+	 * Constructs a new <code>DMinMax</code> processor, which converts the input to a Double and ensures the value is
 	 * between the supplied min and max values.
 	 * 
 	 * @param min
@@ -85,7 +85,7 @@ public class DMinMax extends CellProcessorAdaptor implements StringCellProcessor
 	}
 	
 	/**
-	 * Constructs a new <tt>DMinMax</tt> processor, which converts the input to a Double, ensures the value is between
+	 * Constructs a new <code>DMinMax</code> processor, which converts the input to a Double, ensures the value is between
 	 * the supplied min and max values, then calls the next processor in the chain.
 	 * 
 	 * @param min

--- a/super-csv/src/main/java/org/supercsv/cellprocessor/constraint/Equals.java
+++ b/super-csv/src/main/java/org/supercsv/cellprocessor/constraint/Equals.java
@@ -41,7 +41,7 @@ public class Equals extends CellProcessorAdaptor implements BoolCellProcessor, D
 	private boolean constantSupplied;
 	
 	/**
-	 * Constructs a new <tt>Equals</tt> processor, which ensures all input data is equal.
+	 * Constructs a new <code>Equals</code> processor, which ensures all input data is equal.
 	 */
 	public Equals() {
 		super();
@@ -50,7 +50,7 @@ public class Equals extends CellProcessorAdaptor implements BoolCellProcessor, D
 	}
 	
 	/**
-	 * Constructs a new <tt>Equals</tt> processor, which ensures all input data is equal to the supplied constant value.
+	 * Constructs a new <code>Equals</code> processor, which ensures all input data is equal to the supplied constant value.
 	 * 
 	 * @param constantValue
 	 *            the constant value that all input must equal
@@ -62,7 +62,7 @@ public class Equals extends CellProcessorAdaptor implements BoolCellProcessor, D
 	}
 	
 	/**
-	 * Constructs a new <tt>Equals</tt> processor, which ensures all input data is equal, then calls the the next
+	 * Constructs a new <code>Equals</code> processor, which ensures all input data is equal, then calls the the next
 	 * processor in the chain.
 	 * 
 	 * @param next
@@ -77,7 +77,7 @@ public class Equals extends CellProcessorAdaptor implements BoolCellProcessor, D
 	}
 	
 	/**
-	 * Constructs a new <tt>Equals</tt> processor, which ensures all input data is equal to the supplied constant value,
+	 * Constructs a new <code>Equals</code> processor, which ensures all input data is equal to the supplied constant value,
 	 * then calls the the next processor in the chain.
 	 * 
 	 * @param constantValue

--- a/super-csv/src/main/java/org/supercsv/cellprocessor/constraint/ForbidSubStr.java
+++ b/super-csv/src/main/java/org/supercsv/cellprocessor/constraint/ForbidSubStr.java
@@ -39,7 +39,7 @@ public class ForbidSubStr extends CellProcessorAdaptor implements StringCellProc
 	private final List<String> forbiddenSubStrings = new ArrayList<String>();
 	
 	/**
-	 * Constructs a new <tt>ForbidSubStr</tt> processor which ensures the input doesn't contain any of the supplied
+	 * Constructs a new <code>ForbidSubStr</code> processor which ensures the input doesn't contain any of the supplied
 	 * substrings.
 	 * 
 	 * @param forbiddenSubStrings
@@ -56,7 +56,7 @@ public class ForbidSubStr extends CellProcessorAdaptor implements StringCellProc
 	}
 	
 	/**
-	 * Constructs a new <tt>ForbidSubStr</tt> processor which ensures the input doesn't contain any of the supplied
+	 * Constructs a new <code>ForbidSubStr</code> processor which ensures the input doesn't contain any of the supplied
 	 * substrings.
 	 * 
 	 * @param forbiddenSubStrings
@@ -73,7 +73,7 @@ public class ForbidSubStr extends CellProcessorAdaptor implements StringCellProc
 	}
 	
 	/**
-	 * Constructs a new <tt>ForbidSubStr</tt> processor which ensures the input doesn't contain any of the supplied
+	 * Constructs a new <code>ForbidSubStr</code> processor which ensures the input doesn't contain any of the supplied
 	 * substrings, then calls the next processor in the chain.
 	 * 
 	 * @param forbiddenSubStrings
@@ -92,7 +92,7 @@ public class ForbidSubStr extends CellProcessorAdaptor implements StringCellProc
 	}
 	
 	/**
-	 * Constructs a new <tt>ForbidSubStr</tt> processor which ensures the input doesn't contain the supplied substring,
+	 * Constructs a new <code>ForbidSubStr</code> processor which ensures the input doesn't contain the supplied substring,
 	 * then calls the next processor in the chain.
 	 * 
 	 * @param forbiddenSubString
@@ -107,7 +107,7 @@ public class ForbidSubStr extends CellProcessorAdaptor implements StringCellProc
 	}
 	
 	/**
-	 * Constructs a new <tt>ForbidSubStr</tt> processor which ensures the input doesn't contain any of the supplied
+	 * Constructs a new <code>ForbidSubStr</code> processor which ensures the input doesn't contain any of the supplied
 	 * substrings, then calls the next processor in the chain.
 	 * 
 	 * @param forbiddenSubStrings

--- a/super-csv/src/main/java/org/supercsv/cellprocessor/constraint/IsElementOf.java
+++ b/super-csv/src/main/java/org/supercsv/cellprocessor/constraint/IsElementOf.java
@@ -41,7 +41,7 @@ public class IsElementOf extends CellProcessorAdaptor implements BoolCellProcess
 	private final Collection<Object> collection;
 	
 	/**
-	 * Constructs a new <tt>IsElementOf</tt>, which ensures that the input value is an element of a Collection.
+	 * Constructs a new <code>IsElementOf</code>, which ensures that the input value is an element of a Collection.
 	 * 
 	 * @param collection
 	 *            the collection to check
@@ -55,7 +55,7 @@ public class IsElementOf extends CellProcessorAdaptor implements BoolCellProcess
 	}
 	
 	/**
-	 * Constructs a new <tt>IsElementOf</tt>, which ensures that the input value is an element of a Collection, then
+	 * Constructs a new <code>IsElementOf</code>, which ensures that the input value is an element of a Collection, then
 	 * calls the next processor in the chain.
 	 * 
 	 * @param collection

--- a/super-csv/src/main/java/org/supercsv/cellprocessor/constraint/IsIncludedIn.java
+++ b/super-csv/src/main/java/org/supercsv/cellprocessor/constraint/IsIncludedIn.java
@@ -44,7 +44,7 @@ public class IsIncludedIn extends CellProcessorAdaptor implements BoolCellProces
 	private final Set<Object> possibleValues = new HashSet<Object>();
 	
 	/**
-	 * Constructs a new <tt>IsIncludedIn</tt> processor, which ensures that the input value belongs to a specific set of
+	 * Constructs a new <code>IsIncludedIn</code> processor, which ensures that the input value belongs to a specific set of
 	 * given values.
 	 * 
 	 * @param possibleValues
@@ -61,7 +61,7 @@ public class IsIncludedIn extends CellProcessorAdaptor implements BoolCellProces
 	}
 	
 	/**
-	 * Constructs a new <tt>IsIncludedIn</tt> processor, which ensures that the input value belongs to a specific set of
+	 * Constructs a new <code>IsIncludedIn</code> processor, which ensures that the input value belongs to a specific set of
 	 * given values, then calls the next processor in the chain.
 	 * 
 	 * @param possibleValues
@@ -80,7 +80,7 @@ public class IsIncludedIn extends CellProcessorAdaptor implements BoolCellProces
 	}
 	
 	/**
-	 * Constructs a new <tt>IsIncludedIn</tt> processor, which ensures that the input value belongs to a specific set of
+	 * Constructs a new <code>IsIncludedIn</code> processor, which ensures that the input value belongs to a specific set of
 	 * given values.
 	 * 
 	 * @param possibleValues
@@ -97,7 +97,7 @@ public class IsIncludedIn extends CellProcessorAdaptor implements BoolCellProces
 	}
 	
 	/**
-	 * Constructs a new <tt>IsIncludedIn</tt> processor, which ensures that the input value belongs to a specific set of
+	 * Constructs a new <code>IsIncludedIn</code> processor, which ensures that the input value belongs to a specific set of
 	 * given values, then calls the next processor in the chain.
 	 * 
 	 * @param possibleValues

--- a/super-csv/src/main/java/org/supercsv/cellprocessor/constraint/LMinMax.java
+++ b/super-csv/src/main/java/org/supercsv/cellprocessor/constraint/LMinMax.java
@@ -73,7 +73,7 @@ public class LMinMax extends CellProcessorAdaptor implements StringCellProcessor
 	private final long max;
 	
 	/**
-	 * Constructs a new <tt>LMinMax</tt> processor, which converts the input data to a Long and and ensures the value is
+	 * Constructs a new <code>LMinMax</code> processor, which converts the input data to a Long and and ensures the value is
 	 * between the supplied min and max values.
 	 * 
 	 * @param min
@@ -91,7 +91,7 @@ public class LMinMax extends CellProcessorAdaptor implements StringCellProcessor
 	}
 	
 	/**
-	 * Constructs a new <tt>LMinMax</tt> processor, which converts the input data to a Long and and ensures the value is
+	 * Constructs a new <code>LMinMax</code> processor, which converts the input data to a Long and and ensures the value is
 	 * between the supplied min and max values, then calls the next processor in the chain.
 	 * 
 	 * @param min

--- a/super-csv/src/main/java/org/supercsv/cellprocessor/constraint/NotNull.java
+++ b/super-csv/src/main/java/org/supercsv/cellprocessor/constraint/NotNull.java
@@ -27,7 +27,7 @@ import org.supercsv.exception.SuperCsvConstraintViolationException;
 import org.supercsv.util.CsvContext;
 
 /**
- * This processor ensures that the input is not <tt>null</tt>.
+ * This processor ensures that the input is not <code>null</code>.
  * <p>
  * You should only use this processor when a column must be non-null, but you do not need to apply any other processor
  * to the column (i.e. a mandatory String column with no other conversions or constraints)
@@ -42,15 +42,15 @@ public class NotNull extends CellProcessorAdaptor implements BoolCellProcessor, 
 	LongCellProcessor, StringCellProcessor {
 	
 	/**
-	 * Constructs a new <tt>NotNull</tt> which ensures that the input is not <tt>null</tt>.
+	 * Constructs a new <code>NotNull</code> which ensures that the input is not <code>null</code>.
 	 */
 	public NotNull() {
 		super();
 	}
 	
 	/**
-	 * Constructs a new <tt>NotNull</tt> which ensures that the input is not <tt>null</tt>, then calls the next
-	 * processor in the chain. All other processor should check for <tt>null</tt> inputs, so this constructor is not
+	 * Constructs a new <code>NotNull</code> which ensures that the input is not <code>null</code>, then calls the next
+	 * processor in the chain. All other processor should check for <code>null</code> inputs, so this constructor is not
 	 * typically required.
 	 * 
 	 * @param next

--- a/super-csv/src/main/java/org/supercsv/cellprocessor/constraint/RequireHashCode.java
+++ b/super-csv/src/main/java/org/supercsv/cellprocessor/constraint/RequireHashCode.java
@@ -36,7 +36,7 @@ import org.supercsv.util.CsvContext;
  * This constraint is a very efficient way of ensuring constant expressions are present in certain columns of the CSV
  * file, such as "BOSS", "EMPLOYEE", or when a column denotes an action to be taken for the input line such as "D"
  * (delete), "I" (insert), ...
- * <p>
+ * </p>
  * 
  * @since 1.50
  * @author Kasper B. Graversen
@@ -48,7 +48,7 @@ public class RequireHashCode extends CellProcessorAdaptor implements BoolCellPro
 	private final Set<Integer> requiredHashCodes = new HashSet<Integer>();
 	
 	/**
-	 * Constructs a new <tt>RequireHashCode</tt> processor, which converts the input to a String, and ensures that the
+	 * Constructs a new <code>RequireHashCode</code> processor, which converts the input to a String, and ensures that the
 	 * input's hash function matches any of a given set of hashcodes.
 	 * 
 	 * @param requiredHashcodes
@@ -67,7 +67,7 @@ public class RequireHashCode extends CellProcessorAdaptor implements BoolCellPro
 	}
 	
 	/**
-	 * Constructs a new <tt>RequireHashCode</tt> processor, which converts the input to a String, ensures that the
+	 * Constructs a new <code>RequireHashCode</code> processor, which converts the input to a String, ensures that the
 	 * input's hash function matches the supplied hashcode, then calls the next processor in the chain.
 	 * 
 	 * @param requiredHashcode
@@ -82,7 +82,7 @@ public class RequireHashCode extends CellProcessorAdaptor implements BoolCellPro
 	}
 	
 	/**
-	 * Constructs a new <tt>RequireHashCode</tt> processor, which converts the input to a String, ensures that the
+	 * Constructs a new <code>RequireHashCode</code> processor, which converts the input to a String, ensures that the
 	 * input's hash function matches any of a given set of hashcodes, then calls the next processor in the chain.
 	 * 
 	 * @param requiredHashcodes

--- a/super-csv/src/main/java/org/supercsv/cellprocessor/constraint/StrMinMax.java
+++ b/super-csv/src/main/java/org/supercsv/cellprocessor/constraint/StrMinMax.java
@@ -36,7 +36,7 @@ public class StrMinMax extends CellProcessorAdaptor implements StringCellProcess
 	private final long max;
 	
 	/**
-	 * Constructs a new <tt>StrMinMax</tt> processor, which ensures that the input data has a string length between the
+	 * Constructs a new <code>StrMinMax</code> processor, which ensures that the input data has a string length between the
 	 * supplied min and max values (both inclusive).
 	 * 
 	 * @param min
@@ -54,7 +54,7 @@ public class StrMinMax extends CellProcessorAdaptor implements StringCellProcess
 	}
 	
 	/**
-	 * Constructs a new <tt>StrMinMax</tt> processor, which ensures that the input data has a string length between the
+	 * Constructs a new <code>StrMinMax</code> processor, which ensures that the input data has a string length between the
 	 * supplied min and max values (both inclusive), then calls the next processor in the chain.
 	 * 
 	 * @param min

--- a/super-csv/src/main/java/org/supercsv/cellprocessor/constraint/StrNotNullOrEmpty.java
+++ b/super-csv/src/main/java/org/supercsv/cellprocessor/constraint/StrNotNullOrEmpty.java
@@ -23,7 +23,7 @@ import org.supercsv.exception.SuperCsvConstraintViolationException;
 import org.supercsv.util.CsvContext;
 
 /**
- * This processor checks if the input is <tt>null</tt> or an empty string, and raises an exception in that case. In all
+ * This processor checks if the input is <code>null</code> or an empty string, and raises an exception in that case. In all
  * other cases, the next processor in the chain is invoked.
  * <p>
  * You should only use this processor, when a column must be non-null, but you do not need to apply any other processor
@@ -38,14 +38,14 @@ import org.supercsv.util.CsvContext;
 public class StrNotNullOrEmpty extends CellProcessorAdaptor implements StringCellProcessor {
 	
 	/**
-	 * Constructs a new <tt>StrNotNullOrEmpty</tt> processor, which checks for null/empty Strings.
+	 * Constructs a new <code>StrNotNullOrEmpty</code> processor, which checks for null/empty Strings.
 	 */
 	public StrNotNullOrEmpty() {
 		super();
 	}
 	
 	/**
-	 * Constructs a new <tt>StrNotNullOrEmpty</tt> processor, which checks for null/empty Strings, then calls the next
+	 * Constructs a new <code>StrNotNullOrEmpty</code> processor, which checks for null/empty Strings, then calls the next
 	 * processor in the chain.
 	 * 
 	 * @param next

--- a/super-csv/src/main/java/org/supercsv/cellprocessor/constraint/StrRegEx.java
+++ b/super-csv/src/main/java/org/supercsv/cellprocessor/constraint/StrRegEx.java
@@ -41,7 +41,7 @@ public class StrRegEx extends CellProcessorAdaptor implements StringCellProcesso
 	private static final Map<String, String> REGEX_MSGS = new HashMap<String, String>();
 	
 	/**
-	 * Constructs a new <tt>StrRegEx</tt> processor, which ensures that the input data matches the given regular
+	 * Constructs a new <code>StrRegEx</code> processor, which ensures that the input data matches the given regular
 	 * expression.
 	 * 
 	 * @param regex
@@ -61,7 +61,7 @@ public class StrRegEx extends CellProcessorAdaptor implements StringCellProcesso
 	}
 	
 	/**
-	 * Constructs a new <tt>StrRegEx</tt> processor, which ensures that the input data matches the given regular
+	 * Constructs a new <code>StrRegEx</code> processor, which ensures that the input data matches the given regular
 	 * expression, then calls the next processor in the chain.
 	 * 
 	 * @param regex

--- a/super-csv/src/main/java/org/supercsv/cellprocessor/constraint/Strlen.java
+++ b/super-csv/src/main/java/org/supercsv/cellprocessor/constraint/Strlen.java
@@ -38,7 +38,7 @@ public class Strlen extends CellProcessorAdaptor implements StringCellProcessor 
 	private final Set<Integer> requiredLengths = new HashSet<Integer>();
 	
 	/**
-	 * Constructs a new <tt>Strlen</tt> processor, which ensures that the input String has a length equal to any of the
+	 * Constructs a new <code>Strlen</code> processor, which ensures that the input String has a length equal to any of the
 	 * supplied lengths.
 	 * 
 	 * @param requiredLengths
@@ -55,7 +55,7 @@ public class Strlen extends CellProcessorAdaptor implements StringCellProcessor 
 	}
 	
 	/**
-	 * Constructs a new <tt>Strlen</tt> processor, which ensures that the input String has a length equal to the
+	 * Constructs a new <code>Strlen</code> processor, which ensures that the input String has a length equal to the
 	 * supplied length, then calls the next processor in the chain.
 	 * 
 	 * @param requiredLength
@@ -72,7 +72,7 @@ public class Strlen extends CellProcessorAdaptor implements StringCellProcessor 
 	}
 	
 	/**
-	 * Constructs a new <tt>Strlen</tt> processor, which ensures that the input String has a length equal to any of the
+	 * Constructs a new <code>Strlen</code> processor, which ensures that the input String has a length equal to any of the
 	 * supplied lengths, then calls the next processor in the chain.
 	 * 
 	 * @param requiredLengths

--- a/super-csv/src/main/java/org/supercsv/cellprocessor/constraint/Unique.java
+++ b/super-csv/src/main/java/org/supercsv/cellprocessor/constraint/Unique.java
@@ -26,7 +26,7 @@ import org.supercsv.util.CsvContext;
 
 /**
  * Ensure that upon processing a CSV file (reading or writing), that values of the column all are unique. Comparison is
- * based upon each elements <tt>equals()</tt> method of the objects and lookup takes O(1).
+ * based upon each elements <code>equals()</code> method of the objects and lookup takes O(1).
  * <P>
  * Compared to {@link UniqueHashCode} this processor potentially uses more memory, as it stores references to each
  * encountered object rather than just their hashcodes. On reading huge files this can be a real memory-hazard, however,
@@ -42,14 +42,14 @@ public class Unique extends CellProcessorAdaptor {
 	private final Set<Object> encounteredElements = new HashSet<Object>();
 	
 	/**
-	 * Constructs a new <tt>Unique</tt> processor, which ensures that all rows in a column are unique.
+	 * Constructs a new <code>Unique</code> processor, which ensures that all rows in a column are unique.
 	 */
 	public Unique() {
 		super();
 	}
 	
 	/**
-	 * Constructs a new <tt>Unique</tt> processor, which ensures that all rows in a column are unique, then calls the
+	 * Constructs a new <code>Unique</code> processor, which ensures that all rows in a column are unique, then calls the
 	 * next processor in the chain.
 	 * 
 	 * @param next

--- a/super-csv/src/main/java/org/supercsv/cellprocessor/constraint/UniqueHashCode.java
+++ b/super-csv/src/main/java/org/supercsv/cellprocessor/constraint/UniqueHashCode.java
@@ -26,12 +26,12 @@ import org.supercsv.util.CsvContext;
 
 /**
  * Ensure that upon processing a CSV file (reading or writing), that values of the column are all unique. Comparison is
- * based upon each elements <tt>hashCode()</tt> method and lookup takes O(1).
+ * based upon each elements <code>hashCode()</code> method and lookup takes O(1).
  * <p>
  * Compared to {@link Unique} this processor is much more memory efficient as it only stores the set of encountered
  * hashcodes rather than storing references to all encountered objects. The tradeoff being possible false positives.
  * <p>
- * Prior to v1.50 this class was named <tt>Unique</tt> but has been renamed to clarify its inner workings.
+ * Prior to v1.50 this class was named <code>Unique</code> but has been renamed to clarify its inner workings.
  * 
  * @author Kasper B. Graversen
  * @author Dominique De Vito
@@ -42,14 +42,14 @@ public class UniqueHashCode extends CellProcessorAdaptor {
 	private final Set<Integer> uniqueSet = new HashSet<Integer>();
 	
 	/**
-	 * Constructs a new <tt>UniqueHashCode</tt> processor, which ensures that all rows in a column are unique.
+	 * Constructs a new <code>UniqueHashCode</code> processor, which ensures that all rows in a column are unique.
 	 */
 	public UniqueHashCode() {
 		super();
 	}
 	
 	/**
-	 * Constructs a new <tt>UniqueHashCode</tt> processor, which ensures that all rows in a column are unique, then
+	 * Constructs a new <code>UniqueHashCode</code> processor, which ensures that all rows in a column are unique, then
 	 * calls the next processor in the chain.
 	 * 
 	 * @param next

--- a/super-csv/src/main/java/org/supercsv/cellprocessor/constraint/package-info.java
+++ b/super-csv/src/main/java/org/supercsv/cellprocessor/constraint/package-info.java
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 /**
- * Provides <tt>CellProcessor</tt> classes for enforcing constraints.
+ * Provides <code>CellProcessor</code> classes for enforcing constraints.
  * <p>
  * Note however, that in order for these processors to carry out their constraint logic, they may convert the input
- * data. For example, the <tt>Strlen</tt> constraint, given the number 17, converts it to the string <tt>"17"</tt> before doing its length
+ * data. For example, the <code>Strlen</code> constraint, given the number 17, converts it to the string <code>"17"</code> before doing its length
  * check.
  */
 package org.supercsv.cellprocessor.constraint;

--- a/super-csv/src/main/java/org/supercsv/cellprocessor/ift/BoolCellProcessor.java
+++ b/super-csv/src/main/java/org/supercsv/cellprocessor/ift/BoolCellProcessor.java
@@ -16,7 +16,7 @@
 package org.supercsv.cellprocessor.ift;
 
 /**
- * Interface to indicate the a <tt>CellProcessor</tt> is capable of processing Boolean values.
+ * Interface to indicate the a <code>CellProcessor</code> is capable of processing Boolean values.
  */
 public interface BoolCellProcessor extends CellProcessor {
 }

--- a/super-csv/src/main/java/org/supercsv/cellprocessor/ift/CellProcessor.java
+++ b/super-csv/src/main/java/org/supercsv/cellprocessor/ift/CellProcessor.java
@@ -18,7 +18,7 @@ package org.supercsv.cellprocessor.ift;
 import org.supercsv.util.CsvContext;
 
 /**
- * Defines the interface of all <tt>CellProcessor</tt>s.
+ * Defines the interface of all <code>CellProcessor</code>s.
  */
 public interface CellProcessor {
 	

--- a/super-csv/src/main/java/org/supercsv/cellprocessor/ift/DateCellProcessor.java
+++ b/super-csv/src/main/java/org/supercsv/cellprocessor/ift/DateCellProcessor.java
@@ -16,7 +16,7 @@
 package org.supercsv.cellprocessor.ift;
 
 /**
- * Interface to indicate the a <tt>CellProcessor</tt> is capable of processing Date values.
+ * Interface to indicate the a <code>CellProcessor</code> is capable of processing Date values.
  */
 public interface DateCellProcessor extends CellProcessor {
 }

--- a/super-csv/src/main/java/org/supercsv/cellprocessor/ift/DoubleCellProcessor.java
+++ b/super-csv/src/main/java/org/supercsv/cellprocessor/ift/DoubleCellProcessor.java
@@ -16,7 +16,7 @@
 package org.supercsv.cellprocessor.ift;
 
 /**
- * Interface to indicate the a <tt>CellProcessor</tt> is capable of processing Double values.
+ * Interface to indicate the a <code>CellProcessor</code> is capable of processing Double values.
  */
 public interface DoubleCellProcessor extends CellProcessor {
 }

--- a/super-csv/src/main/java/org/supercsv/cellprocessor/ift/LongCellProcessor.java
+++ b/super-csv/src/main/java/org/supercsv/cellprocessor/ift/LongCellProcessor.java
@@ -16,7 +16,7 @@
 package org.supercsv.cellprocessor.ift;
 
 /**
- * Interface to indicate the a <tt>CellProcessor</tt> is capable of processing Long values.
+ * Interface to indicate the a <code>CellProcessor</code> is capable of processing Long values.
  */
 public interface LongCellProcessor extends CellProcessor {
 }

--- a/super-csv/src/main/java/org/supercsv/cellprocessor/ift/StringCellProcessor.java
+++ b/super-csv/src/main/java/org/supercsv/cellprocessor/ift/StringCellProcessor.java
@@ -16,7 +16,7 @@
 package org.supercsv.cellprocessor.ift;
 
 /**
- * Interface to indicate the a <tt>CellProcessor</tt> is capable of processing String values.
+ * Interface to indicate the a <code>CellProcessor</code> is capable of processing String values.
  */
 public interface StringCellProcessor extends CellProcessor {
 }

--- a/super-csv/src/main/java/org/supercsv/cellprocessor/ift/package-info.java
+++ b/super-csv/src/main/java/org/supercsv/cellprocessor/ift/package-info.java
@@ -14,6 +14,6 @@
  * limitations under the License.
  */
 /**
- * Provides <tt>CellProcessor</tt> interfaces, used to control/restrict how processors can be chained together.
+ * Provides <code>CellProcessor</code> interfaces, used to control/restrict how processors can be chained together.
  */
 package org.supercsv.cellprocessor.ift;

--- a/super-csv/src/main/java/org/supercsv/cellprocessor/package-info.java
+++ b/super-csv/src/main/java/org/supercsv/cellprocessor/package-info.java
@@ -14,6 +14,6 @@
  * limitations under the License.
  */
 /**
- * Provides <tt>CellProcessor</tt> classes for conversion, formatting and parsing.
+ * Provides <code>CellProcessor</code> classes for conversion, formatting and parsing.
  */
 package org.supercsv.cellprocessor;

--- a/super-csv/src/main/java/org/supercsv/comment/CommentMatches.java
+++ b/super-csv/src/main/java/org/supercsv/comment/CommentMatches.java
@@ -26,7 +26,7 @@ public class CommentMatches implements CommentMatcher {
 	private final Pattern pattern;
 	
 	/**
-	 * Constructs a new <tt>CommentMatches</tt> comment matcher. Ensure that the regex is efficient (ideally matching start/end
+	 * Constructs a new <code>CommentMatches</code> comment matcher. Ensure that the regex is efficient (ideally matching start/end
 	 * characters) as a complex regex can significantly slow down reading.
 	 * 
 	 * @param regex

--- a/super-csv/src/main/java/org/supercsv/comment/CommentStartsWith.java
+++ b/super-csv/src/main/java/org/supercsv/comment/CommentStartsWith.java
@@ -23,7 +23,7 @@ public class CommentStartsWith implements CommentMatcher {
 	private final String value;
 	
 	/**
-	 * Constructs a new <tt>CommentStartsWith</tt> comment matcher.
+	 * Constructs a new <code>CommentStartsWith</code> comment matcher.
 	 * 
 	 * @param value
 	 *            the String a line must start with to be a comment

--- a/super-csv/src/main/java/org/supercsv/encoder/DefaultCsvEncoder.java
+++ b/super-csv/src/main/java/org/supercsv/encoder/DefaultCsvEncoder.java
@@ -27,7 +27,7 @@ import org.supercsv.util.CsvContext;
 public class DefaultCsvEncoder implements CsvEncoder {
 	
 	/**
-	 * Constructs a new <tt>DefaultCsvEncoder</tt>.
+	 * Constructs a new <code>DefaultCsvEncoder</code>.
 	 */
 	public DefaultCsvEncoder() {
 	}

--- a/super-csv/src/main/java/org/supercsv/encoder/SelectiveCsvEncoder.java
+++ b/super-csv/src/main/java/org/supercsv/encoder/SelectiveCsvEncoder.java
@@ -33,7 +33,7 @@ public class SelectiveCsvEncoder extends DefaultCsvEncoder {
 	private final Set<Integer> columnNumbers = new HashSet<Integer>();
 	
 	/**
-	 * Constructs a new <tt>SelectiveCsvEncoder</tt> that encodes columns by column number. If no column numbers are
+	 * Constructs a new <code>SelectiveCsvEncoder</code> that encodes columns by column number. If no column numbers are
 	 * supplied (i.e. no parameters) then no columns will be encoded.
 	 * 
 	 * @param columnsToEncode
@@ -51,7 +51,7 @@ public class SelectiveCsvEncoder extends DefaultCsvEncoder {
 	}
 	
 	/**
-	 * Constructs a new <tt>SelectiveCsvEncoder</tt> that encodes columns if the element representing that column in the
+	 * Constructs a new <code>SelectiveCsvEncoder</code> that encodes columns if the element representing that column in the
 	 * supplied array is true.
 	 * 
 	 * @param columnsToEncode

--- a/super-csv/src/main/java/org/supercsv/exception/SuperCsvCellProcessorException.java
+++ b/super-csv/src/main/java/org/supercsv/exception/SuperCsvCellProcessorException.java
@@ -32,7 +32,7 @@ public class SuperCsvCellProcessorException extends SuperCsvException {
 	private final CellProcessor processor;
 	
 	/**
-	 * Constructs a new <tt>SuperCsvCellProcessorException</tt>.
+	 * Constructs a new <code>SuperCsvCellProcessorException</code>.
 	 * 
 	 * @param msg
 	 *            the exception message
@@ -47,7 +47,7 @@ public class SuperCsvCellProcessorException extends SuperCsvException {
 	}
 	
 	/**
-	 * Constructs a new <tt>SuperCsvCellProcessorException</tt>.
+	 * Constructs a new <code>SuperCsvCellProcessorException</code>.
 	 * 
 	 * @param msg
 	 *            the exception message
@@ -65,7 +65,7 @@ public class SuperCsvCellProcessorException extends SuperCsvException {
 	}
 	
 	/**
-	 * Constructs a new <tt>SuperCsvCellProcessorException</tt> to indicate that the value received by a CellProcessor
+	 * Constructs a new <code>SuperCsvCellProcessorException</code> to indicate that the value received by a CellProcessor
 	 * wasn't of the correct type.
 	 * 
 	 * @param expectedType

--- a/super-csv/src/main/java/org/supercsv/exception/SuperCsvConstraintViolationException.java
+++ b/super-csv/src/main/java/org/supercsv/exception/SuperCsvConstraintViolationException.java
@@ -32,7 +32,7 @@ public class SuperCsvConstraintViolationException extends SuperCsvCellProcessorE
 	private static final long serialVersionUID = 1L;
 	
 	/**
-	 * Constructs a new <tt>SuperCsvConstraintViolationException</tt>.
+	 * Constructs a new <code>SuperCsvConstraintViolationException</code>.
 	 * 
 	 * @param msg
 	 *            the exception message
@@ -47,7 +47,7 @@ public class SuperCsvConstraintViolationException extends SuperCsvCellProcessorE
 	}
 	
 	/**
-	 * Constructs a new <tt>SuperCsvConstraintViolationException</tt>.
+	 * Constructs a new <code>SuperCsvConstraintViolationException</code>.
 	 * 
 	 * @param msg
 	 *            the exception message

--- a/super-csv/src/main/java/org/supercsv/exception/SuperCsvException.java
+++ b/super-csv/src/main/java/org/supercsv/exception/SuperCsvException.java
@@ -31,7 +31,7 @@ public class SuperCsvException extends RuntimeException {
 	private CsvContext csvContext;
 	
 	/**
-	 * Constructs a new <tt>SuperCsvException</tt>.
+	 * Constructs a new <code>SuperCsvException</code>.
 	 * 
 	 * @param msg
 	 *            the exception message
@@ -41,7 +41,7 @@ public class SuperCsvException extends RuntimeException {
 	}
 	
 	/**
-	 * Constructs a new <tt>SuperCsvException</tt>.
+	 * Constructs a new <code>SuperCsvException</code>.
 	 * 
 	 * @param msg
 	 *            the exception message
@@ -56,7 +56,7 @@ public class SuperCsvException extends RuntimeException {
 	}
 	
 	/**
-	 * Constructs a new <tt>SuperCsvException</tt>.
+	 * Constructs a new <code>SuperCsvException</code>.
 	 * 
 	 * @param msg
 	 *            the exception message
@@ -75,7 +75,7 @@ public class SuperCsvException extends RuntimeException {
 	/**
 	 * Gets the current CSV context.
 	 * 
-	 * @return the current CSV context, or <tt>null</tt> if none is available
+	 * @return the current CSV context, or <code>null</code> if none is available
 	 */
 	public CsvContext getCsvContext() {
 		return csvContext;

--- a/super-csv/src/main/java/org/supercsv/exception/SuperCsvReflectionException.java
+++ b/super-csv/src/main/java/org/supercsv/exception/SuperCsvReflectionException.java
@@ -18,10 +18,10 @@ package org.supercsv.exception;
 /**
  * Wraps the following reflection related checked exceptions:
  * <p>
- * <tt>
+ * <code>
  * ClassNotFoundException, IllegalAccessException, InstantiationException, InvocationTargetException,
- * NoSuchMethodException</tt>
- * <p>
+ * NoSuchMethodException</code>
+ * </p>
  * 
  * @since 1.30
  * @author Kasper B. Graversen
@@ -31,7 +31,7 @@ public class SuperCsvReflectionException extends SuperCsvException {
 	private static final long serialVersionUID = 1L;
 	
 	/**
-	 * Constructs a new <tt>SuperCsvReflectionException</tt>.
+	 * Constructs a new <code>SuperCsvReflectionException</code>.
 	 * 
 	 * @param msg
 	 *            the exception message
@@ -41,7 +41,7 @@ public class SuperCsvReflectionException extends SuperCsvException {
 	}
 	
 	/**
-	 * Constructs a new <tt>SuperCsvReflectionException</tt>.
+	 * Constructs a new <code>SuperCsvReflectionException</code>.
 	 * 
 	 * @param msg
 	 *            the exception message

--- a/super-csv/src/main/java/org/supercsv/io/AbstractCsvReader.java
+++ b/super-csv/src/main/java/org/supercsv/io/AbstractCsvReader.java
@@ -45,7 +45,7 @@ public abstract class AbstractCsvReader implements ICsvReader {
 	private int rowNumber = 0;
 	
 	/**
-	 * Constructs a new <tt>AbstractCsvReader</tt>, using the default {@link Tokenizer}.
+	 * Constructs a new <code>AbstractCsvReader</code>, using the default {@link Tokenizer}.
 	 * 
 	 * @param reader
 	 *            the reader
@@ -66,7 +66,7 @@ public abstract class AbstractCsvReader implements ICsvReader {
 	}
 	
 	/**
-	 * Constructs a new <tt>AbstractCsvReader</tt>, using a custom {@link Tokenizer} (which should have already been set
+	 * Constructs a new <code>AbstractCsvReader</code>, using a custom {@link Tokenizer} (which should have already been set
 	 * up with the Reader, CsvPreference, and CsvContext). This constructor should only be used if the default Tokenizer
 	 * doesn't provide the required functionality.
 	 * 

--- a/super-csv/src/main/java/org/supercsv/io/AbstractCsvWriter.java
+++ b/super-csv/src/main/java/org/supercsv/io/AbstractCsvWriter.java
@@ -49,7 +49,7 @@ public abstract class AbstractCsvWriter implements ICsvWriter {
 	private int columnNumber = 0;
 	
 	/**
-	 * Constructs a new <tt>AbstractCsvWriter</tt> with the supplied writer and preferences.
+	 * Constructs a new <code>AbstractCsvWriter</code> with the supplied writer and preferences.
 	 * 
 	 * @param writer
 	 *            the stream to write to
@@ -63,7 +63,7 @@ public abstract class AbstractCsvWriter implements ICsvWriter {
 	}
 	
 	/**
-	 * Constructs a new <tt>AbstractCsvWriter</tt> with the supplied writer, preferences and option
+	 * Constructs a new <code>AbstractCsvWriter</code> with the supplied writer, preferences and option
 	 * to wrap the writer.
 	 * 
 	 * @param writer

--- a/super-csv/src/main/java/org/supercsv/io/AbstractTokenizer.java
+++ b/super-csv/src/main/java/org/supercsv/io/AbstractTokenizer.java
@@ -37,7 +37,7 @@ public abstract class AbstractTokenizer implements ITokenizer {
 	private final LineNumberReader lnr;
 	
 	/**
-	 * Constructs a new <tt>AbstractTokenizer</tt>, which reads the CSV file, line by line.
+	 * Constructs a new <code>AbstractTokenizer</code>, which reads the CSV file, line by line.
 	 * 
 	 * @param reader
 	 *            the reader
@@ -75,7 +75,7 @@ public abstract class AbstractTokenizer implements ITokenizer {
 	 * Reads a line of text. Whenever a line terminator is read the current line number is incremented.
 	 * 
 	 * @return A String containing the contents of the line, not including any line termination characters, or
-	 *         <tt>null</tt> if the end of the stream has been reached
+	 *         <code>null</code> if the end of the stream has been reached
 	 * @throws IOException
 	 *             If an I/O error occurs
 	 */

--- a/super-csv/src/main/java/org/supercsv/io/CsvBeanReader.java
+++ b/super-csv/src/main/java/org/supercsv/io/CsvBeanReader.java
@@ -50,8 +50,8 @@ public class CsvBeanReader extends AbstractCsvReader implements ICsvBeanReader {
 	private final MethodCache cache = new MethodCache();
 	
 	/**
-	 * Constructs a new <tt>CsvBeanReader</tt> with the supplied Reader and CSV preferences. Note that the
-	 * <tt>reader</tt> will be wrapped in a <tt>BufferedReader</tt> before accessed.
+	 * Constructs a new <code>CsvBeanReader</code> with the supplied Reader and CSV preferences. Note that the
+	 * <code>reader</code> will be wrapped in a <code>BufferedReader</code> before accessed.
 	 * 
 	 * @param reader
 	 *            the reader
@@ -65,7 +65,7 @@ public class CsvBeanReader extends AbstractCsvReader implements ICsvBeanReader {
 	}
 	
 	/**
-	 * Constructs a new <tt>CsvBeanReader</tt> with the supplied (custom) Tokenizer and CSV preferences. The tokenizer
+	 * Constructs a new <code>CsvBeanReader</code> with the supplied (custom) Tokenizer and CSV preferences. The tokenizer
 	 * should be set up with the Reader (CSV input) and CsvPreference beforehand.
 	 * 
 	 * @param tokenizer

--- a/super-csv/src/main/java/org/supercsv/io/CsvBeanWriter.java
+++ b/super-csv/src/main/java/org/supercsv/io/CsvBeanWriter.java
@@ -46,8 +46,8 @@ public class CsvBeanWriter extends AbstractCsvWriter implements ICsvBeanWriter {
 	private final MethodCache cache = new MethodCache();
 	
 	/**
-	 * Constructs a new <tt>CsvBeanWriter</tt> with the supplied Writer and CSV preferences. Note that the
-	 * <tt>writer</tt> will be wrapped in a <tt>BufferedWriter</tt> before accessed.
+	 * Constructs a new <code>CsvBeanWriter</code> with the supplied Writer and CSV preferences. Note that the
+	 * <code>writer</code> will be wrapped in a <code>BufferedWriter</code> before accessed.
 	 * 
 	 * @param writer
 	 *            the writer

--- a/super-csv/src/main/java/org/supercsv/io/CsvListReader.java
+++ b/super-csv/src/main/java/org/supercsv/io/CsvListReader.java
@@ -24,7 +24,7 @@ import org.supercsv.cellprocessor.ift.CellProcessor;
 import org.supercsv.prefs.CsvPreference;
 
 /**
- * CsvListReader is a simple reader that reads a row from a CSV file into a <tt>List</tt> of Strings.
+ * CsvListReader is a simple reader that reads a row from a CSV file into a <code>List</code> of Strings.
  * 
  * @author Kasper B. Graversen
  * @author James Bassett
@@ -32,8 +32,8 @@ import org.supercsv.prefs.CsvPreference;
 public class CsvListReader extends AbstractCsvReader implements ICsvListReader {
 	
 	/**
-	 * Constructs a new <tt>CsvListReader</tt> with the supplied Reader and CSV preferences. Note that the
-	 * <tt>reader</tt> will be wrapped in a <tt>BufferedReader</tt> before accessed.
+	 * Constructs a new <code>CsvListReader</code> with the supplied Reader and CSV preferences. Note that the
+	 * <code>reader</code> will be wrapped in a <code>BufferedReader</code> before accessed.
 	 * 
 	 * @param reader
 	 *            the reader
@@ -47,7 +47,7 @@ public class CsvListReader extends AbstractCsvReader implements ICsvListReader {
 	}
 	
 	/**
-	 * Constructs a new <tt>CsvListReader</tt> with the supplied (custom) Tokenizer and CSV preferences. The tokenizer
+	 * Constructs a new <code>CsvListReader</code> with the supplied (custom) Tokenizer and CSV preferences. The tokenizer
 	 * should be set up with the Reader (CSV input) and CsvPreference beforehand.
 	 * 
 	 * @param tokenizer

--- a/super-csv/src/main/java/org/supercsv/io/CsvListWriter.java
+++ b/super-csv/src/main/java/org/supercsv/io/CsvListWriter.java
@@ -36,8 +36,8 @@ public class CsvListWriter extends AbstractCsvWriter implements ICsvListWriter {
 	private final List<Object> processedColumns = new ArrayList<Object>();
 	
 	/**
-	 * Constructs a new <tt>CsvListWriter</tt> with the supplied Writer and CSV preferences. Note that the
-	 * <tt>reader</tt> will be wrapped in a <tt>BufferedReader</tt> before accessed.
+	 * Constructs a new <code>CsvListWriter</code> with the supplied Writer and CSV preferences. Note that the
+	 * <code>reader</code> will be wrapped in a <code>BufferedReader</code> before accessed.
 	 * 
 	 * @param writer
 	 *            the writer

--- a/super-csv/src/main/java/org/supercsv/io/CsvMapReader.java
+++ b/super-csv/src/main/java/org/supercsv/io/CsvMapReader.java
@@ -36,8 +36,8 @@ import org.supercsv.util.Util;
 public class CsvMapReader extends AbstractCsvReader implements ICsvMapReader {
 	
 	/**
-	 * Constructs a new <tt>CsvMapReader</tt> with the supplied Reader and CSV preferences. Note that the
-	 * <tt>reader</tt> will be wrapped in a <tt>BufferedReader</tt> before accessed.
+	 * Constructs a new <code>CsvMapReader</code> with the supplied Reader and CSV preferences. Note that the
+	 * <code>reader</code> will be wrapped in a <code>BufferedReader</code> before accessed.
 	 * 
 	 * @param reader
 	 *            the reader
@@ -51,7 +51,7 @@ public class CsvMapReader extends AbstractCsvReader implements ICsvMapReader {
 	}
 	
 	/**
-	 * Constructs a new <tt>CsvMapReader</tt> with the supplied (custom) Tokenizer and CSV preferences. The tokenizer
+	 * Constructs a new <code>CsvMapReader</code> with the supplied (custom) Tokenizer and CSV preferences. The tokenizer
 	 * should be set up with the Reader (CSV input) and CsvPreference beforehand.
 	 * 
 	 * @param tokenizer

--- a/super-csv/src/main/java/org/supercsv/io/CsvMapWriter.java
+++ b/super-csv/src/main/java/org/supercsv/io/CsvMapWriter.java
@@ -37,8 +37,8 @@ public class CsvMapWriter extends AbstractCsvWriter implements ICsvMapWriter {
 	private final List<Object> processedColumns = new ArrayList<Object>();
 	
 	/**
-	 * Constructs a new <tt>CsvMapWriter</tt> with the supplied Writer and CSV preferences. Note that the
-	 * <tt>writer</tt> will be wrapped in a <tt>BufferedWriter</tt> before accessed.
+	 * Constructs a new <code>CsvMapWriter</code> with the supplied Writer and CSV preferences. Note that the
+	 * <code>writer</code> will be wrapped in a <code>BufferedWriter</code> before accessed.
 	 * 
 	 * @param writer
 	 *            the writer
@@ -53,7 +53,7 @@ public class CsvMapWriter extends AbstractCsvWriter implements ICsvMapWriter {
 	}
 
 	/**
-	 * Constructs a new <tt>CsvMapWriter</tt> with the supplied Writer, CSV preferences and option
+	 * Constructs a new <code>CsvMapWriter</code> with the supplied Writer, CSV preferences and option
 	 * to bufferize the writer.
 	 *
 	 * @param writer
@@ -61,8 +61,8 @@ public class CsvMapWriter extends AbstractCsvWriter implements ICsvMapWriter {
 	 * @param preference
 	 *            the CSV preferences
 	 * @param bufferizeWriter
-	 *            if {@code true}, the <tt>writer</tt> will be wrapped in
-	 *            a <tt>BufferedWriter</tt> before accessed.
+	 *            if {@code true}, the <code>writer</code> will be wrapped in
+	 *            a <code>BufferedWriter</code> before accessed.
 	 * @throws NullPointerException
 	 *             if writer or preference is null
 	 * @since 1.0

--- a/super-csv/src/main/java/org/supercsv/io/ICsvBeanReader.java
+++ b/super-csv/src/main/java/org/supercsv/io/ICsvBeanReader.java
@@ -40,7 +40,7 @@ public interface ICsvBeanReader extends ICsvReader {
 	 *            be created instead.
 	 * @param nameMapping
 	 *            an array of Strings linking the CSV columns to their corresponding field in the bean (the array length
-	 *            should match the number of columns). A <tt>null</tt> entry in the array indicates that the column
+	 *            should match the number of columns). A <code>null</code> entry in the array indicates that the column
 	 *            should be ignored (the field in the bean will be null - or its default value).
 	 * @param <T>
 	 *            the bean type
@@ -67,7 +67,7 @@ public interface ICsvBeanReader extends ICsvReader {
 	 *            the bean to populate
 	 * @param nameMapping
 	 *            an array of Strings linking the CSV columns to their corresponding field in the bean (the array length
-	 *            should match the number of columns). A <tt>null</tt> entry in the array indicates that the column
+	 *            should match the number of columns). A <code>null</code> entry in the array indicates that the column
 	 *            should be ignored (the field in the bean will be null - or its default value).
 	 * @param <T>
 	 *            the bean type
@@ -90,7 +90,7 @@ public interface ICsvBeanReader extends ICsvReader {
 	 * Reads a row of a CSV file and populates an instance of the specified class, using the supplied name mapping to
 	 * map column values to the appropriate fields. Before population the data can be further processed by cell
 	 * processors (as with the nameMapping array, each element in the processors array corresponds with a CSV column). A
-	 * <tt>null</tt> entry in the processors array indicates no further processing is required (the unprocessed String
+	 * <code>null</code> entry in the processors array indicates no further processing is required (the unprocessed String
 	 * value will be set on the bean's field).
 	 * 
 	 * @param clazz
@@ -99,12 +99,12 @@ public interface ICsvBeanReader extends ICsvReader {
 	 *            be created instead.
 	 * @param nameMapping
 	 *            an array of Strings linking the CSV columns to their corresponding field in the bean (the array length
-	 *            should match the number of columns). A <tt>null</tt> entry in the array indicates that the column
+	 *            should match the number of columns). A <code>null</code> entry in the array indicates that the column
 	 *            should be ignored (the field in the bean will be null - or its default value).
 	 * @param processors
 	 *            an array of CellProcessors used to further process data before it is populated on the bean (each
 	 *            element in the processors array corresponds with a CSV column - the number of processors should match
-	 *            the number of columns). A <tt>null</tt> entry indicates no further processing is required (the
+	 *            the number of columns). A <code>null</code> entry indicates no further processing is required (the
 	 *            unprocessed String value will be set on the bean's field).
 	 * @param <T>
 	 *            the bean type
@@ -126,7 +126,7 @@ public interface ICsvBeanReader extends ICsvReader {
 	/**
 	 * Reads a row of a CSV file and populates the bean, using the supplied name mapping to map column values to the
 	 * appropriate fields. Before population the data can be further processed by cell processors (as with the
-	 * nameMapping array, each element in the processors array corresponds with a CSV column). A <tt>null</tt> entry in
+	 * nameMapping array, each element in the processors array corresponds with a CSV column). A <code>null</code> entry in
 	 * the processors array indicates no further processing is required (the unprocessed String value will be set on the
 	 * bean's field).
 	 * 
@@ -134,12 +134,12 @@ public interface ICsvBeanReader extends ICsvReader {
 	 *            the bean to populate
 	 * @param nameMapping
 	 *            an array of Strings linking the CSV columns to their corresponding field in the bean (the array length
-	 *            should match the number of columns). A <tt>null</tt> entry in the array indicates that the column
+	 *            should match the number of columns). A <code>null</code> entry in the array indicates that the column
 	 *            should be ignored (the field in the bean will be null - or its default value).
 	 * @param processors
 	 *            an array of CellProcessors used to further process data before it is populated on the bean (each
 	 *            element in the processors array corresponds with a CSV column - the number of processors should match
-	 *            the number of columns). A <tt>null</tt> entry indicates no further processing is required (the
+	 *            the number of columns). A <code>null</code> entry indicates no further processing is required (the
 	 *            unprocessed String value will be set on the bean's field).
 	 * @param <T>
 	 *            the bean type

--- a/super-csv/src/main/java/org/supercsv/io/ICsvBeanWriter.java
+++ b/super-csv/src/main/java/org/supercsv/io/ICsvBeanWriter.java
@@ -31,13 +31,13 @@ public interface ICsvBeanWriter extends ICsvWriter {
 	
 	/**
 	 * Writes the fields of the object as columns of a CSV file, using the supplied name mapping to map fields to the
-	 * appropriate columns. <tt>toString()</tt> will be called on each element prior to writing.
+	 * appropriate columns. <code>toString()</code> will be called on each element prior to writing.
 	 * 
 	 * @param source
 	 *            the object (bean instance) containing the values to write
 	 * @param nameMapping
 	 *            an array of Strings linking the fields in the bean to their corresponding CSV columns (the array
-	 *            length should match the number of columns). A <tt>null</tt> entry in the array indicates that the
+	 *            length should match the number of columns). A <code>null</code> entry in the array indicates that the
 	 *            column should be ignored (the column will be empty).
 	 * @throws IOException
 	 *             if an I/O error occurred
@@ -53,18 +53,18 @@ public interface ICsvBeanWriter extends ICsvWriter {
 	
 	/**
 	 * Writes the fields of the object as columns of a CSV file, using the supplied name mapping to map fields to the
-	 * appropriate columns. <tt>toString()</tt> will be called on each (processed) element prior to writing.
+	 * appropriate columns. <code>toString()</code> will be called on each (processed) element prior to writing.
 	 * 
 	 * @param source
 	 *            the object (bean instance) containing the values to write
 	 * @param nameMapping
 	 *            an array of Strings linking the fields in the bean to their corresponding CSV columns (the array
-	 *            length should match the number of columns). A <tt>null</tt> entry in the array indicates that the
+	 *            length should match the number of columns). A <code>null</code> entry in the array indicates that the
 	 *            column should be ignored (the column will be empty).
 	 * @param processors
 	 *            an array of CellProcessors used to further process data before it is written (each element in the
 	 *            processors array corresponds with a CSV column - the number of processors should match the number of
-	 *            columns). A <tt>null</tt> entry indicates no further processing is required (the value returned by
+	 *            columns). A <code>null</code> entry indicates no further processing is required (the value returned by
 	 *            toString() will be written as the column value).
 	 * @throws IOException
 	 *             if an I/O error occurred

--- a/super-csv/src/main/java/org/supercsv/io/ICsvListReader.java
+++ b/super-csv/src/main/java/org/supercsv/io/ICsvListReader.java
@@ -47,14 +47,14 @@ public interface ICsvListReader extends ICsvReader {
 	
 	/**
 	 * Reads a row of a CSV file and returns a List of Objects containing each column. The data can be further processed
-	 * by cell processors (each element in the processors array corresponds with a CSV column). A <tt>null</tt> entry in
+	 * by cell processors (each element in the processors array corresponds with a CSV column). A <code>null</code> entry in
 	 * the processors array indicates no further processing is required (the unprocessed String value will be added to
 	 * the List). Prior to version 2.0.0 this method returned a List of Strings.
 	 * 
 	 * @param processors
 	 *            an array of CellProcessors used to further process data before it is added to the List (each element
 	 *            in the processors array corresponds with a CSV column - the number of processors should match the
-	 *            number of columns). A <tt>null</tt> entry indicates no further processing is required (the unprocessed
+	 *            number of columns). A <code>null</code> entry indicates no further processing is required (the unprocessed
 	 *            String value will be added to the List).
 	 * @return the List of columns, or null if EOF
 	 * @throws IOException
@@ -77,7 +77,7 @@ public interface ICsvListReader extends ICsvReader {
 	 * @param processors
 	 *            an array of CellProcessors used to further process the last row of CSV data that was read (each
 	 *            element in the processors array corresponds with a CSV column - the number of processors should match
-	 *            the number of columns). A <tt>null</tt> entry indicates no further processing is required (the
+	 *            the number of columns). A <code>null</code> entry indicates no further processing is required (the
 	 *            unprocessed String value will be added to the List).
 	 * @return the List of processed columns
 	 * @throws NullPointerException

--- a/super-csv/src/main/java/org/supercsv/io/ICsvListWriter.java
+++ b/super-csv/src/main/java/org/supercsv/io/ICsvListWriter.java
@@ -31,7 +31,7 @@ import org.supercsv.exception.SuperCsvException;
 public interface ICsvListWriter extends ICsvWriter {
 	
 	/**
-	 * Writes a List of Objects as columns of a CSV file. <tt>toString()</tt> will be called on each element prior to
+	 * Writes a List of Objects as columns of a CSV file. <code>toString()</code> will be called on each element prior to
 	 * writing.
 	 * 
 	 * @param columns
@@ -50,14 +50,14 @@ public interface ICsvListWriter extends ICsvWriter {
 	
 	/**
 	 * Writes a List of Objects as columns of a CSV file, performing any necessary processing beforehand.
-	 * <tt>toString()</tt> will be called on each (processed) element prior to writing.
+	 * <code>toString()</code> will be called on each (processed) element prior to writing.
 	 * 
 	 * @param columns
 	 *            the columns to write
 	 * @param processors
 	 *            an array of CellProcessors used to further process data before it is written (each element in the
 	 *            processors array corresponds with a CSV column - the number of processors should match the number of
-	 *            columns). A <tt>null</tt> entry indicates no further processing is required (the value returned by
+	 *            columns). A <code>null</code> entry indicates no further processing is required (the value returned by
 	 *            toString() will be written as the column value).
 	 * @throws IllegalArgumentException
 	 *             if columns.size == 0
@@ -74,7 +74,7 @@ public interface ICsvListWriter extends ICsvWriter {
 	void write(List<?> columns, CellProcessor[] processors) throws IOException;
 	
 	/**
-	 * Writes a array of Objects as columns of a CSV file. <tt>toString()</tt> will be called on each element prior to
+	 * Writes a array of Objects as columns of a CSV file. <code>toString()</code> will be called on each element prior to
 	 * writing.
 	 * 
 	 * @param columns

--- a/super-csv/src/main/java/org/supercsv/io/ICsvMapReader.java
+++ b/super-csv/src/main/java/org/supercsv/io/ICsvMapReader.java
@@ -36,7 +36,7 @@ public interface ICsvMapReader extends ICsvReader {
 	 * 
 	 * @param nameMapping
 	 *            an array of Strings linking the CSV columns to their corresponding entry in the Map (the array length
-	 *            should match the number of columns). A <tt>null</tt> entry in the array indicates that the column
+	 *            should match the number of columns). A <code>null</code> entry in the array indicates that the column
 	 *            should be ignored (e.g. not added to the Map).
 	 * @return a Map of column names to column values (Strings, as no processing is performed), or null if EOF
 	 * @throws IOException
@@ -55,12 +55,12 @@ public interface ICsvMapReader extends ICsvReader {
 	 * 
 	 * @param nameMapping
 	 *            an array of Strings linking the CSV columns to their corresponding entry in the Map (the array length
-	 *            should match the number of columns). A <tt>null</tt> entry in the array indicates that the column
+	 *            should match the number of columns). A <code>null</code> entry in the array indicates that the column
 	 *            should be ignored (e.g. not added to the Map).
 	 * @param processors
 	 *            an array of CellProcessors used to further process data before it is added to the Map (each element in
 	 *            the processors array corresponds with a CSV column - the number of processors should match the number
-	 *            of columns). A <tt>null</tt> entry indicates no further processing is required (the unprocessed String
+	 *            of columns). A <code>null</code> entry indicates no further processing is required (the unprocessed String
 	 *            value will added to the Map).
 	 * @return a Map of column names to column values, or null if EOF
 	 * @throws IOException

--- a/super-csv/src/main/java/org/supercsv/io/ICsvMapWriter.java
+++ b/super-csv/src/main/java/org/supercsv/io/ICsvMapWriter.java
@@ -32,13 +32,13 @@ public interface ICsvMapWriter extends ICsvWriter {
 	
 	/**
 	 * Writes the values of the Map as columns of a CSV file, using the supplied name mapping to map values to the
-	 * appropriate columns. <tt>toString()</tt> will be called on each element prior to writing.
+	 * appropriate columns. <code>toString()</code> will be called on each element prior to writing.
 	 * 
 	 * @param values
 	 *            the Map containing the values to write
 	 * @param nameMapping
 	 *            an array of Strings linking the Map keys to their corresponding CSV columns (the array length should
-	 *            match the number of columns). A <tt>null</tt> entry in the array indicates that the column should be
+	 *            match the number of columns). A <code>null</code> entry in the array indicates that the column should be
 	 *            ignored (the column will be empty).
 	 * @throws IOException
 	 *             if an I/O error occurred
@@ -52,18 +52,18 @@ public interface ICsvMapWriter extends ICsvWriter {
 	
 	/**
 	 * Writes the values of the Map as columns of a CSV file, using the supplied name mapping to map values to the
-	 * appropriate columns. <tt>toString()</tt> will be called on each element prior to writing.
+	 * appropriate columns. <code>toString()</code> will be called on each element prior to writing.
 	 * 
 	 * @param values
 	 *            the Map containing the values to write
 	 * @param nameMapping
 	 *            an array of Strings linking the Map keys to their corresponding CSV columns (the array length should
-	 *            match the number of columns). A <tt>null</tt> entry in the array indicates that the column should be
+	 *            match the number of columns). A <code>null</code> entry in the array indicates that the column should be
 	 *            ignored (the column will be empty).
 	 * @param processors
 	 *            an array of CellProcessors used to further process data before it is written (each element in the
 	 *            processors array corresponds with a CSV column - the number of processors should match the number of
-	 *            columns). A <tt>null</tt> entry indicates no further processing is required (the value returned by
+	 *            columns). A <code>null</code> entry indicates no further processing is required (the value returned by
 	 *            toString() will be written as the column value).
 	 * @throws IOException
 	 *             if an I/O error occurred

--- a/super-csv/src/main/java/org/supercsv/io/ITokenizer.java
+++ b/super-csv/src/main/java/org/supercsv/io/ITokenizer.java
@@ -53,7 +53,7 @@ public interface ITokenizer extends Closeable {
 	/**
 	 * Reads a CSV row into the supplied List of columns (which can potentially span multiple lines in the file). The
 	 * columns list is cleared as the first operation in the method. Any empty columns ("") will be added to the list as
-	 * <tt>null</tt>.
+	 * <code>null</code>.
 	 * 
 	 * @param columns
 	 *            the List of columns to read into

--- a/super-csv/src/main/java/org/supercsv/io/Tokenizer.java
+++ b/super-csv/src/main/java/org/supercsv/io/Tokenizer.java
@@ -67,7 +67,7 @@ public class Tokenizer extends AbstractTokenizer {
 	}
 	
 	/**
-	 * Constructs a new <tt>Tokenizer</tt>, which reads the CSV file, line by line.
+	 * Constructs a new <code>Tokenizer</code>, which reads the CSV file, line by line.
 	 * 
 	 * @param reader
 	 *            the reader

--- a/super-csv/src/main/java/org/supercsv/io/package-info.java
+++ b/super-csv/src/main/java/org/supercsv/io/package-info.java
@@ -15,6 +15,6 @@
  */
 /**
  * Provides the various readers and writers used to read/write Strings, Maps, or Objects. In order to
- * use a reader/writer it should be configured with <tt>CellProcessor</tt>s and a <tt>CSVPreference</tt>.
+ * use a reader/writer it should be configured with <code>CellProcessor</code>s and a <code>CSVPreference</code>.
  */
 package org.supercsv.io;

--- a/super-csv/src/main/java/org/supercsv/prefs/CsvPreference.java
+++ b/super-csv/src/main/java/org/supercsv/prefs/CsvPreference.java
@@ -27,14 +27,14 @@ import org.supercsv.quote.QuoteMode;
  * <p>
  * <strong>Please note:</strong> the end of line symbols are <em>only</em> used for writing.
  * </p>
- * <table border="0" cellpadding="1" >
+ * <table>
  * <caption>Predefined configurations</caption>
  * <tbody>
  * <tr>
- * <th align="left">Constant</th>
- * <th align="left">Quote character</th>
- * <th align="left">Delimiter character</th>
- * <th align="left">End of line symbols</th>
+ * <th>Constant</th>
+ * <th>Quote character</th>
+ * <th>Delimiter character</th>
+ * <th>End of line symbols</th>
  * </tr>
  * <tr>
  * <td><code>STANDARD_PREFERENCE</code></td>
@@ -69,7 +69,7 @@ import org.supercsv.quote.QuoteMode;
  * </p>
  * <p>
  * If you wish enable this functionality again, then you can create a CsvPreference with the
- * <tt>surroundingSpacesNeedQuotes</tt> flag set to true (the default is false). This means that surrounding spaces
+ * <code>surroundingSpacesNeedQuotes</code> flag set to true (the default is false). This means that surrounding spaces
  * without quotes will be trimmed when reading, and quotes will automatically be added for Strings containing
  * surrounding spaces when writing.
  * </p>
@@ -151,7 +151,7 @@ public final class CsvPreference {
 	private final char quoteEscapeChar;
 	
 	/**
-	 * Constructs a new <tt>CsvPreference</tt> from a Builder.
+	 * Constructs a new <code>CsvPreference</code> from a Builder.
 	 */
 	private CsvPreference(Builder builder) {
 		this.quoteChar = builder.quoteChar;
@@ -269,7 +269,7 @@ public final class CsvPreference {
 	}
 
 	/**
-	 * Builds immutable <tt>CsvPreference</tt> instances. The builder pattern allows for additional preferences to be
+	 * Builds immutable <code>CsvPreference</code> instances. The builder pattern allows for additional preferences to be
 	 * added in the future.
 	 */
 	public static class Builder {
@@ -297,7 +297,7 @@ public final class CsvPreference {
 		private char quoteEscapeChar;
 		
 		/**
-		 * Constructs a Builder with all of the values from an existing <tt>CsvPreference</tt> instance. Useful if you
+		 * Constructs a Builder with all of the values from an existing <code>CsvPreference</code> instance. Useful if you
 		 * want to base your preferences off one of the existing CsvPreference constants.
 		 * 
 		 * @param preference
@@ -348,7 +348,7 @@ public final class CsvPreference {
 		
 		/**
 		 * Flag indicating whether spaces at the beginning or end of a cell should be ignored if they're not surrounded
-		 * by quotes (applicable to both reading and writing CSV). The default is <tt>false</tt>, as spaces
+		 * by quotes (applicable to both reading and writing CSV). The default is <code>false</code>, as spaces
 		 * "are considered part of a field and should not be ignored" according to RFC 4180.
 		 * 
 		 * @since 2.0.0
@@ -364,7 +364,7 @@ public final class CsvPreference {
 		
 		/**
 		 * Flag indicating whether empty lines (i.e. containing only end of line symbols) should be ignored. The default
-		 * is <tt>true</tt>.
+		 * is <code>true</code>.
 		 * 
 		 * @since 2.2.1
 		 * @param ignoreEmptyLines
@@ -440,7 +440,7 @@ public final class CsvPreference {
 		 * CSV). This option allows CSV readers to fail fast when encountering CSV with mismatching quotes - the normal
 		 * behaviour would be to continue reading until the matching quote is found, which could potentially mean
 		 * reading the whole file (and exhausting all available memory). Zero or a negative value will disable this
-		 * option. The default is <tt>0</tt>.
+		 * option. The default is <code>0</code>.
 		 * 
 		 * @since 2.4.0
 		 * @param maxLinesPerRow
@@ -454,7 +454,7 @@ public final class CsvPreference {
 		
 		/**
 		 * Uses an EmptyColumnParsing to determine whether empty String (i.e. "") should be read as empty string instead as null.
-		 * The default is <tt>ParseEmptyColumnsAsNull</tt>.
+		 * The default is <code>ParseEmptyColumnsAsNull</code>.
 		 *
 		 * @since 2.4.1
 		 * @param emptyColumnParsing
@@ -471,8 +471,8 @@ public final class CsvPreference {
 
 		/**
 		 * Value indicating the character to use for escaping a quote char.  The default value is
-		 * the quote char (which is a double-quote <tt>"</tt> character by default).  This value
-		 * must not be the same as <tt>delimiterChar</tt>
+		 * the quote char (which is a double-quote <code>"</code> character by default).  This value
+		 * must not be the same as <code>delimiterChar</code>
 		 *
 		 * @since 2.5.0
 		 * @param quoteEscapeChar

--- a/super-csv/src/main/java/org/supercsv/quote/AlwaysQuoteMode.java
+++ b/super-csv/src/main/java/org/supercsv/quote/AlwaysQuoteMode.java
@@ -27,7 +27,7 @@ import org.supercsv.util.CsvContext;
 public class AlwaysQuoteMode implements QuoteMode {
 	
 	/**
-	 * Constructs a new <tt>AlwaysQuoteMode</tt>.
+	 * Constructs a new <code>AlwaysQuoteMode</code>.
 	 */
 	public AlwaysQuoteMode() {
 	}

--- a/super-csv/src/main/java/org/supercsv/quote/ColumnQuoteMode.java
+++ b/super-csv/src/main/java/org/supercsv/quote/ColumnQuoteMode.java
@@ -33,7 +33,7 @@ public class ColumnQuoteMode implements QuoteMode {
 	private final Set<Integer> columnNumbers = new HashSet<Integer>();
 	
 	/**
-	 * Constructs a new <tt>ColumnQuoteMode</tt> that quotes columns by column number. If no column numbers are supplied
+	 * Constructs a new <code>ColumnQuoteMode</code> that quotes columns by column number. If no column numbers are supplied
 	 * (i.e. no parameters) then quoting will be determined per RFC4180.
 	 * 
 	 * @param columnsToQuote
@@ -51,8 +51,8 @@ public class ColumnQuoteMode implements QuoteMode {
 	}
 	
 	/**
-	 * Constructs a new <tt>ColumnQuoteMode</tt> that quotes columns if the element representing that column in the
-	 * supplied array is true. Please note that <tt>false</tt> doesn't disable quoting, it just means that quoting is
+	 * Constructs a new <code>ColumnQuoteMode</code> that quotes columns if the element representing that column in the
+	 * supplied array is true. Please note that <code>false</code> doesn't disable quoting, it just means that quoting is
 	 * determined by RFC4180.
 	 * 
 	 * @param columnsToQuote

--- a/super-csv/src/main/java/org/supercsv/quote/NormalQuoteMode.java
+++ b/super-csv/src/main/java/org/supercsv/quote/NormalQuoteMode.java
@@ -28,7 +28,7 @@ import org.supercsv.util.CsvContext;
 public class NormalQuoteMode implements QuoteMode {
 	
 	/**
-	 * Constructs a new <tt>NormalQuoteMode</tt>.
+	 * Constructs a new <code>NormalQuoteMode</code>.
 	 */
 	public NormalQuoteMode() {
 	}

--- a/super-csv/src/main/java/org/supercsv/util/CsvContext.java
+++ b/super-csv/src/main/java/org/supercsv/util/CsvContext.java
@@ -45,7 +45,7 @@ public class CsvContext implements Serializable {
 	private List<Object> rowSource;
 	
 	/**
-	 * Constructs a new <tt>CsvContext</tt>.
+	 * Constructs a new <code>CsvContext</code>.
 	 * 
 	 * @param lineNumber
 	 *            the current line number
@@ -61,7 +61,7 @@ public class CsvContext implements Serializable {
 	}
 	
 	/**
-	 * Constructs a new <tt>CsvContext</tt> that is a copy of the provided <tt>CsvContext</tt>. 
+	 * Constructs a new <code>CsvContext</code> that is a copy of the provided <code>CsvContext</code>. 
 	 * 
 	 * @param c the context to be copied
 	 */

--- a/super-csv/src/main/java/org/supercsv/util/ReflectionUtils.java
+++ b/super-csv/src/main/java/org/supercsv/util/ReflectionUtils.java
@@ -195,7 +195,7 @@ public final class ReflectionUtils {
 	/**
 	 * Helper method for findSetter() that returns the setter method of the supplied name, whose parameter type is
 	 * compatible with the supplied argument type (will allow an object of that type to be used when invoking the
-	 * setter), or returns <tt>null</tt> if no match is found. Preference is given to setters whose parameter type is an
+	 * setter), or returns <code>null</code> if no match is found. Preference is given to setters whose parameter type is an
 	 * exact match, but if there is none, then the first compatible method found is returned.
 	 * 
 	 * @param clazz

--- a/super-csv/src/main/java/org/supercsv/util/ThreeDHashMap.java
+++ b/super-csv/src/main/java/org/supercsv/util/ThreeDHashMap.java
@@ -38,13 +38,13 @@ public class ThreeDHashMap<K1, K2, K3, V> {
 	private final HashMap<K1, HashMap<K2, HashMap<K3, V>>> map = new HashMap<K1, HashMap<K2, HashMap<K3, V>>>();
 	
 	/**
-	 * Existence check of a value (or <tt>null</tt>) mapped to the keys.
+	 * Existence check of a value (or <code>null</code>) mapped to the keys.
 	 * 
 	 * @param firstKey
 	 *            first key
 	 * @param secondKey
 	 *            second key
-	 * @return true when an element (or <tt>null</tt>) has been stored with the keys
+	 * @return true when an element (or <code>null</code>) has been stored with the keys
 	 */
 	public boolean containsKey(final K1 firstKey, final K2 secondKey) {
 		// existence check on inner map
@@ -57,7 +57,7 @@ public class ThreeDHashMap<K1, K2, K3, V> {
 	}
 	
 	/**
-	 * Existence check of a value (or <tt>null</tt>) mapped to the keys.
+	 * Existence check of a value (or <code>null</code>) mapped to the keys.
 	 * 
 	 * @param firstKey
 	 *            first key
@@ -65,7 +65,7 @@ public class ThreeDHashMap<K1, K2, K3, V> {
 	 *            second key
 	 * @param thirdKey
 	 *            third key
-	 * @return true when an element (or <tt>null</tt>) has been stored with the keys
+	 * @return true when an element (or <code>null</code>) has been stored with the keys
 	 */
 	public boolean containsKey(final K1 firstKey, final K2 secondKey, final K3 thirdKey) {
 		// existence check on inner map
@@ -165,7 +165,7 @@ public class ThreeDHashMap<K1, K2, K3, V> {
 	 * @param thirdKey
 	 *            third key
 	 * @param value
-	 *            the value to be inserted. <tt>null</tt> may be inserted as well.
+	 *            the value to be inserted. <code>null</code> may be inserted as well.
 	 * @return null or the value the insert is replacing.
 	 */
 	public Object set(final K1 firstKey, final K2 secondKey, final K3 thirdKey, final V value) {

--- a/super-csv/src/main/java/org/supercsv/util/TwoDHashMap.java
+++ b/super-csv/src/main/java/org/supercsv/util/TwoDHashMap.java
@@ -37,14 +37,14 @@ public class TwoDHashMap<K1, K2, V> {
 	private final HashMap<K1, HashMap<K2, V>> map;
 	
 	/**
-	 * Constructs a new <tt>TwoDHashMap</tt>.
+	 * Constructs a new <code>TwoDHashMap</code>.
 	 */
 	public TwoDHashMap() {
 		map = new HashMap<K1, HashMap<K2, V>>();
 	}
 	
 	/**
-	 * Constructs a new <tt>TwoDHashMap</tt> using the supplied map.
+	 * Constructs a new <code>TwoDHashMap</code> using the supplied map.
 	 * 
 	 * @param map
 	 *            the map
@@ -59,13 +59,13 @@ public class TwoDHashMap<K1, K2, V> {
 	}
 	
 	/**
-	 * Existence check of a value (or <tt>null</tt>) mapped to the keys.
+	 * Existence check of a value (or <code>null</code>) mapped to the keys.
 	 * 
 	 * @param firstKey
 	 *            first key
 	 * @param secondKey
 	 *            second key
-	 * @return true when an element (or <tt>null</tt>) has been stored with the keys
+	 * @return true when an element (or <code>null</code>) has been stored with the keys
 	 */
 	public boolean containsKey(final K1 firstKey, final K2 secondKey) {
 		// existence check on inner map
@@ -102,7 +102,7 @@ public class TwoDHashMap<K1, K2, V> {
 	 * @param secondKey
 	 *            second key
 	 * @param value
-	 *            the value to be inserted. <tt>null</tt> may be inserted as well.
+	 *            the value to be inserted. <code>null</code> may be inserted as well.
 	 * @return null or the value the insert is replacing.
 	 */
 	public Object set(final K1 firstKey, final K2 secondKey, final V value) {

--- a/super-csv/src/main/java/org/supercsv/util/Util.java
+++ b/super-csv/src/main/java/org/supercsv/util/Util.java
@@ -37,7 +37,7 @@ public final class Util {
 	
 	/**
 	 * Processes each element in the source List (using the corresponding processor chain in the processors array) and
-	 * adds it to the destination List. A <tt>null</tt> CellProcessor in the array indicates that no processing is
+	 * adds it to the destination List. A <code>null</code> CellProcessor in the array indicates that no processing is
 	 * required and the element should be added as-is.
 	 * 
 	 * @param destination
@@ -46,7 +46,7 @@ public final class Util {
 	 *            the List of source elements to be processed
 	 * @param processors
 	 *            the array of CellProcessors used to process each element. The number of elements in this array must
-	 *            match the size of the source List. A <tt>null</tt> CellProcessor in this array indicates that no
+	 *            match the size of the source List. A <code>null</code> CellProcessor in this array indicates that no
 	 *            processing is required and the element should be added as-is.
 	 * @param lineNo
 	 *            the current line number

--- a/super-csv/src/test/java/org/supercsv/cellprocessor/FmtNumberTest.java
+++ b/super-csv/src/test/java/org/supercsv/cellprocessor/FmtNumberTest.java
@@ -29,7 +29,7 @@ import org.supercsv.mock.IdentityTransform;
 /**
  * Tests the FmtNumber processor. As FmtNumber uses the default locale, this test must be written in a locale
  * independent way (so the test will pass). The test can be run in a different local by specifying the
- * <tt>user.language</tt> and <tt>user.country</tt> JVM properties (i.e. <tt>-Duser.language=de -Duser.country=DE</tt>).
+ * <code>user.language</code> and <code>user.country</code> JVM properties (i.e. <code>-Duser.language=de -Duser.country=DE</code>).
  * 
  * @author Kasper B. Graversen
  * @author James Bassett

--- a/super-csv/src/test/java/org/supercsv/cellprocessor/ParseDateTest.java
+++ b/super-csv/src/test/java/org/supercsv/cellprocessor/ParseDateTest.java
@@ -34,7 +34,7 @@ import org.supercsv.mock.IdentityTransform;
 /**
  * Tests the ParseDate processor. As ParseDate uses the default locale, this test must be written in a locale
  * independent way (so the test will pass). The test can be run in a different local by specifying the
- * <tt>user.language</tt> and <tt>user.country</tt> JVM properties (i.e. <tt>-Duser.language=de -Duser.country=DE</tt>).
+ * <code>user.language</code> and <code>user.country</code> JVM properties (i.e. <code>-Duser.language=de -Duser.country=DE</code>).
  * 
  * @author Kasper B. Graversen
  * @author James Bassett

--- a/super-csv/src/test/java/org/supercsv/mock/IdentityTransform.java
+++ b/super-csv/src/test/java/org/supercsv/mock/IdentityTransform.java
@@ -33,14 +33,14 @@ public class IdentityTransform extends CellProcessorAdaptor implements BoolCellP
 	DoubleCellProcessor, LongCellProcessor, StringCellProcessor {
 	
 	/**
-	 * Constructs a new <tt>IdentityTransform</tt> processor, which simply returns whatever is passed into it.
+	 * Constructs a new <code>IdentityTransform</code> processor, which simply returns whatever is passed into it.
 	 */
 	public IdentityTransform() {
 		super();
 	}
 	
 	/**
-	 * Constructs a new <tt>IdentityTransform</tt> processor which just calls the next processor in the chain.
+	 * Constructs a new <code>IdentityTransform</code> processor which just calls the next processor in the chain.
 	 * 
 	 * @param next
 	 *            the next processor in the chain

--- a/super-csv/src/test/java/org/supercsv/util/BeanInterfaceProxyTest.java
+++ b/super-csv/src/test/java/org/supercsv/util/BeanInterfaceProxyTest.java
@@ -120,8 +120,8 @@ public class BeanInterfaceProxyTest {
 	}
 	
 	/**
-	 * Tests invocation of the <tt>getClass</tt> method, inherited from <tt>Object</tt> (doesn't call the
-	 * <tt>InvocationHandler</tt>, but returns the proxy class!).
+	 * Tests invocation of the <code>getClass</code> method, inherited from <code>Object</code> (doesn't call the
+	 * <code>InvocationHandler</code>, but returns the proxy class!).
 	 */
 	@Test
 	public void testGetClass() {


### PR DESCRIPTION
We fix HTML tags in JavaDoc to make sure that even JDK 17's `javadoc` throws no errors during compilation.