### PR TITLE
Avoid ambiguous assertEquals()

### DIFF
--- a/super-csv/src/test/java/org/supercsv/cellprocessor/ParseCharTest.java
+++ b/super-csv/src/test/java/org/supercsv/cellprocessor/ParseCharTest.java
@@ -52,8 +52,8 @@ public class ParseCharTest {
 	 */
 	@Test
 	public void testValidChar() {
-		assertEquals(CHAR, processor.execute(CHAR, ANONYMOUS_CSVCONTEXT));
-		assertEquals(CHAR, processorChain.execute(CHAR, ANONYMOUS_CSVCONTEXT));
+		assertEquals(Character.valueOf(CHAR), processor.execute(CHAR, ANONYMOUS_CSVCONTEXT));
+		assertEquals(Character.valueOf(CHAR), processorChain.execute(CHAR, ANONYMOUS_CSVCONTEXT));
 	}
 	
 	/**
@@ -61,8 +61,8 @@ public class ParseCharTest {
 	 */
 	@Test
 	public void testStringWithSingleChar() {
-		assertEquals(CHAR, processor.execute(STRING, ANONYMOUS_CSVCONTEXT));
-		assertEquals(CHAR, processorChain.execute(STRING, ANONYMOUS_CSVCONTEXT));
+		assertEquals(Character.valueOf(CHAR), processor.execute(STRING, ANONYMOUS_CSVCONTEXT));
+		assertEquals(Character.valueOf(CHAR), processorChain.execute(STRING, ANONYMOUS_CSVCONTEXT));
 	}
 	
 	/**

--- a/super-csv/src/test/java/org/supercsv/cellprocessor/ParseDoubleTest.java
+++ b/super-csv/src/test/java/org/supercsv/cellprocessor/ParseDoubleTest.java
@@ -55,12 +55,12 @@ public class ParseDoubleTest {
 	@Test
 	public void testValidDoubles() {
 		// positive values
-		assertEquals(POSITIVE_VAL, processor.execute(POSITIVE_VAL, ANONYMOUS_CSVCONTEXT));
-		assertEquals(POSITIVE_VAL, processorChain.execute(POSITIVE_VAL, ANONYMOUS_CSVCONTEXT));
+		assertEquals(Double.valueOf(POSITIVE_VAL), processor.execute(POSITIVE_VAL, ANONYMOUS_CSVCONTEXT));
+		assertEquals(Double.valueOf(POSITIVE_VAL), processorChain.execute(POSITIVE_VAL, ANONYMOUS_CSVCONTEXT));
 		
 		// negative values
-		assertEquals(NEGATIVE_VAL, processor.execute(NEGATIVE_VAL, ANONYMOUS_CSVCONTEXT));
-		assertEquals(NEGATIVE_VAL, processorChain.execute(NEGATIVE_VAL, ANONYMOUS_CSVCONTEXT));
+		assertEquals(Double.valueOf(NEGATIVE_VAL), processor.execute(NEGATIVE_VAL, ANONYMOUS_CSVCONTEXT));
+		assertEquals(Double.valueOf(NEGATIVE_VAL), processorChain.execute(NEGATIVE_VAL, ANONYMOUS_CSVCONTEXT));
 	}
 	
 	/**
@@ -69,12 +69,12 @@ public class ParseDoubleTest {
 	@Test
 	public void testValidDoubleStrings() {
 		// positive values
-		assertEquals(POSITIVE_VAL, processor.execute(POSITIVE_STRING, ANONYMOUS_CSVCONTEXT));
-		assertEquals(POSITIVE_VAL, processorChain.execute(POSITIVE_STRING, ANONYMOUS_CSVCONTEXT));
+		assertEquals(Double.valueOf(POSITIVE_VAL), processor.execute(POSITIVE_STRING, ANONYMOUS_CSVCONTEXT));
+		assertEquals(Double.valueOf(POSITIVE_VAL), processorChain.execute(POSITIVE_STRING, ANONYMOUS_CSVCONTEXT));
 		
 		// negative values
-		assertEquals(NEGATIVE_VAL, processor.execute(NEGATIVE_STRING, ANONYMOUS_CSVCONTEXT));
-		assertEquals(NEGATIVE_VAL, processorChain.execute(NEGATIVE_STRING, ANONYMOUS_CSVCONTEXT));
+		assertEquals(Double.valueOf(NEGATIVE_VAL), processor.execute(NEGATIVE_STRING, ANONYMOUS_CSVCONTEXT));
+		assertEquals(Double.valueOf(NEGATIVE_VAL), processorChain.execute(NEGATIVE_STRING, ANONYMOUS_CSVCONTEXT));
 	}
 	
 	/**

--- a/super-csv/src/test/java/org/supercsv/cellprocessor/ParseIntTest.java
+++ b/super-csv/src/test/java/org/supercsv/cellprocessor/ParseIntTest.java
@@ -55,12 +55,12 @@ public class ParseIntTest {
 	@Test
 	public void testValidInts() {
 		// positive values
-		assertEquals(POSITIVE_VAL, processor.execute(POSITIVE_VAL, ANONYMOUS_CSVCONTEXT));
-		assertEquals(POSITIVE_VAL, processorChain.execute(POSITIVE_VAL, ANONYMOUS_CSVCONTEXT));
+		assertEquals(Integer.valueOf(POSITIVE_VAL), processor.execute(POSITIVE_VAL, ANONYMOUS_CSVCONTEXT));
+		assertEquals(Integer.valueOf(POSITIVE_VAL), processorChain.execute(POSITIVE_VAL, ANONYMOUS_CSVCONTEXT));
 		
 		// negative values
-		assertEquals(NEGATIVE_VAL, processor.execute(NEGATIVE_VAL, ANONYMOUS_CSVCONTEXT));
-		assertEquals(NEGATIVE_VAL, processorChain.execute(NEGATIVE_VAL, ANONYMOUS_CSVCONTEXT));
+		assertEquals(Integer.valueOf(NEGATIVE_VAL), processor.execute(NEGATIVE_VAL, ANONYMOUS_CSVCONTEXT));
+		assertEquals(Integer.valueOf(NEGATIVE_VAL), processorChain.execute(NEGATIVE_VAL, ANONYMOUS_CSVCONTEXT));
 	}
 	
 	/**
@@ -69,12 +69,12 @@ public class ParseIntTest {
 	@Test
 	public void testValidIntStrings() {
 		// positive values
-		assertEquals(POSITIVE_VAL, processor.execute(POSITIVE_STRING, ANONYMOUS_CSVCONTEXT));
-		assertEquals(POSITIVE_VAL, processorChain.execute(POSITIVE_STRING, ANONYMOUS_CSVCONTEXT));
+		assertEquals(Integer.valueOf(POSITIVE_VAL), processor.execute(POSITIVE_STRING, ANONYMOUS_CSVCONTEXT));
+		assertEquals(Integer.valueOf(POSITIVE_VAL), processorChain.execute(POSITIVE_STRING, ANONYMOUS_CSVCONTEXT));
 		
 		// negative values
-		assertEquals(NEGATIVE_VAL, processor.execute(NEGATIVE_STRING, ANONYMOUS_CSVCONTEXT));
-		assertEquals(NEGATIVE_VAL, processorChain.execute(NEGATIVE_STRING, ANONYMOUS_CSVCONTEXT));
+		assertEquals(Integer.valueOf(NEGATIVE_VAL), processor.execute(NEGATIVE_STRING, ANONYMOUS_CSVCONTEXT));
+		assertEquals(Integer.valueOf(NEGATIVE_VAL), processorChain.execute(NEGATIVE_STRING, ANONYMOUS_CSVCONTEXT));
 	}
 	
 	/**

--- a/super-csv/src/test/java/org/supercsv/cellprocessor/ParseLongTest.java
+++ b/super-csv/src/test/java/org/supercsv/cellprocessor/ParseLongTest.java
@@ -56,12 +56,12 @@ public class ParseLongTest {
 	public void testValidLongs() {
 		
 		// positive values
-		assertEquals(POSITIVE_VAL, processor.execute(POSITIVE_VAL, ANONYMOUS_CSVCONTEXT));
-		assertEquals(POSITIVE_VAL, processorChain.execute(POSITIVE_VAL, ANONYMOUS_CSVCONTEXT));
+		assertEquals(Long.valueOf(POSITIVE_VAL), processor.execute(POSITIVE_VAL, ANONYMOUS_CSVCONTEXT));
+		assertEquals(Long.valueOf(POSITIVE_VAL), processorChain.execute(POSITIVE_VAL, ANONYMOUS_CSVCONTEXT));
 		
 		// negative values
-		assertEquals(NEGATIVE_VAL, processor.execute(NEGATIVE_VAL, ANONYMOUS_CSVCONTEXT));
-		assertEquals(NEGATIVE_VAL, processorChain.execute(NEGATIVE_VAL, ANONYMOUS_CSVCONTEXT));
+		assertEquals(Long.valueOf(NEGATIVE_VAL), processor.execute(NEGATIVE_VAL, ANONYMOUS_CSVCONTEXT));
+		assertEquals(Long.valueOf(NEGATIVE_VAL), processorChain.execute(NEGATIVE_VAL, ANONYMOUS_CSVCONTEXT));
 	}
 	
 	/**
@@ -70,12 +70,12 @@ public class ParseLongTest {
 	@Test
 	public void testValidLongStrings() {
 		// positive values
-		assertEquals(POSITIVE_VAL, processor.execute(POSITIVE_STRING, ANONYMOUS_CSVCONTEXT));
-		assertEquals(POSITIVE_VAL, processorChain.execute(POSITIVE_STRING, ANONYMOUS_CSVCONTEXT));
+		assertEquals(Long.valueOf(POSITIVE_VAL), processor.execute(POSITIVE_STRING, ANONYMOUS_CSVCONTEXT));
+		assertEquals(Long.valueOf(POSITIVE_VAL), processorChain.execute(POSITIVE_STRING, ANONYMOUS_CSVCONTEXT));
 		
 		// negative values
-		assertEquals(NEGATIVE_VAL, processor.execute(NEGATIVE_STRING, ANONYMOUS_CSVCONTEXT));
-		assertEquals(NEGATIVE_VAL, processorChain.execute(NEGATIVE_STRING, ANONYMOUS_CSVCONTEXT));
+		assertEquals(Long.valueOf(NEGATIVE_VAL), processor.execute(NEGATIVE_STRING, ANONYMOUS_CSVCONTEXT));
+		assertEquals(Long.valueOf(NEGATIVE_VAL), processorChain.execute(NEGATIVE_STRING, ANONYMOUS_CSVCONTEXT));
 	}
 	
 	/**

--- a/super-csv/src/test/java/org/supercsv/cellprocessor/TokenTest.java
+++ b/super-csv/src/test/java/org/supercsv/cellprocessor/TokenTest.java
@@ -76,8 +76,8 @@ public class TokenTest {
 	@Test
 	public void testTokenNotFound() {
 		// expecting 'foo', not 2
-		assertEquals(TOKEN2, processor.execute(TOKEN2, ANONYMOUS_CSVCONTEXT));
-		assertEquals(TOKEN2, processorChain.execute(TOKEN2, ANONYMOUS_CSVCONTEXT));
+		assertEquals(Integer.valueOf(TOKEN2), processor.execute(TOKEN2, ANONYMOUS_CSVCONTEXT));
+		assertEquals(Integer.valueOf(TOKEN2), processorChain.execute(TOKEN2, ANONYMOUS_CSVCONTEXT));
 		
 		// expecting 2, not 'foo'
 		assertEquals(TOKEN, processor2.execute(TOKEN, ANONYMOUS_CSVCONTEXT));

--- a/super-csv/src/test/java/org/supercsv/cellprocessor/constraint/DMinMaxTest.java
+++ b/super-csv/src/test/java/org/supercsv/cellprocessor/constraint/DMinMaxTest.java
@@ -54,8 +54,8 @@ public class DMinMaxTest {
 	 */
 	@Test
 	public void testValidDouble() {
-		assertEquals(IN_RANGE, processor.execute(IN_RANGE, ANONYMOUS_CSVCONTEXT));
-		assertEquals(IN_RANGE, processorChain.execute(IN_RANGE, ANONYMOUS_CSVCONTEXT));
+		assertEquals(Double.valueOf(IN_RANGE), processor.execute(IN_RANGE, ANONYMOUS_CSVCONTEXT));
+		assertEquals(Double.valueOf(IN_RANGE), processorChain.execute(IN_RANGE, ANONYMOUS_CSVCONTEXT));
 	}
 	
 	/**
@@ -63,8 +63,8 @@ public class DMinMaxTest {
 	 */
 	@Test
 	public void testValidString() {
-		assertEquals(IN_RANGE, processor.execute(String.valueOf(IN_RANGE), ANONYMOUS_CSVCONTEXT));
-		assertEquals(IN_RANGE, processorChain.execute(String.valueOf(IN_RANGE), ANONYMOUS_CSVCONTEXT));
+		assertEquals(Double.valueOf(IN_RANGE), processor.execute(String.valueOf(IN_RANGE), ANONYMOUS_CSVCONTEXT));
+		assertEquals(Double.valueOf(IN_RANGE), processorChain.execute(String.valueOf(IN_RANGE), ANONYMOUS_CSVCONTEXT));
 	}
 	
 	/**
@@ -73,7 +73,7 @@ public class DMinMaxTest {
 	@Test
 	public void testChainedAfterStringCellProcessor() {
 		final CellProcessor chain = new StrReplace("zero", "0", new DMinMax(MIN, MAX));
-		assertEquals(0.0, chain.execute("zero", ANONYMOUS_CSVCONTEXT));
+		assertEquals(Double.valueOf(0.0d), chain.execute("zero", ANONYMOUS_CSVCONTEXT));
 	}
 	
 	/**

--- a/super-csv/src/test/java/org/supercsv/cellprocessor/constraint/LMinMaxTest.java
+++ b/super-csv/src/test/java/org/supercsv/cellprocessor/constraint/LMinMaxTest.java
@@ -53,7 +53,7 @@ public class LMinMaxTest {
 	 */
 	@Test
 	public void testValidLong() {
-		long input = 123L;
+		Long input = 123L;
 		assertEquals(input, processor.execute(input, ANONYMOUS_CSVCONTEXT));
 		assertEquals(input, processorChain.execute(input, ANONYMOUS_CSVCONTEXT));
 	}
@@ -74,7 +74,7 @@ public class LMinMaxTest {
 	 */
 	@Test
 	public void testMinBoundary() {
-		long input = MIN_INTEGER;
+		Long input = (long) MIN_INTEGER;
 		assertEquals(input, processor.execute(input, ANONYMOUS_CSVCONTEXT));
 		assertEquals(input, processorChain.execute(input, ANONYMOUS_CSVCONTEXT));
 	}
@@ -84,7 +84,7 @@ public class LMinMaxTest {
 	 */
 	@Test
 	public void testMaxBoundary() {
-		long input = MAX_INTEGER;
+		Long input = (long) MAX_INTEGER;
 		assertEquals(input, processor.execute(input, ANONYMOUS_CSVCONTEXT));
 		assertEquals(input, processorChain.execute(input, ANONYMOUS_CSVCONTEXT));
 	}
@@ -95,7 +95,7 @@ public class LMinMaxTest {
 	@Test
 	public void testChainedAfterStringCellProcessor() {
 		final CellProcessor chain = new StrReplace("zero", "0", new LMinMax(MIN_INTEGER, MAX_INTEGER));
-		assertEquals(0L, chain.execute("zero", ANONYMOUS_CSVCONTEXT));
+		assertEquals(Long.valueOf(0L), chain.execute("zero", ANONYMOUS_CSVCONTEXT));
 	}
 	
 	/**


### PR DESCRIPTION
The `assertEquals(...)` calls in tests were ambiguous. For example, when called with `(long, Long)` parameters, both `assertEquals(Object,Object)` and `assertEquals(long,long)` were applicable. This PR makes the calls unambiguous.