### PR TITLE
:sparkles: Issue#157 - use fluent getters and setters

### DIFF
--- a/super-csv/src/main/java/org/supercsv/util/ReflectionUtils.java
+++ b/super-csv/src/main/java/org/supercsv/util/ReflectionUtils.java
@@ -15,11 +15,11 @@
  */
 package org.supercsv.util;
 
+import org.supercsv.exception.SuperCsvReflectionException;
+
 import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Map;
-
-import org.supercsv.exception.SuperCsvReflectionException;
 
 /**
  * Provides useful utility methods for reflection.
@@ -92,7 +92,11 @@ public final class ReflectionUtils {
 			final String booleanGetterName = getMethodNameForField(IS_PREFIX, fieldName);
 			getter = findGetterWithCompatibleReturnType(booleanGetterName, clazz, true);
 		}
-		
+
+		if (getter == null) {
+			getter = findGetterWithCompatibleReturnType(fieldName, clazz, false);
+		}
+
 		if( getter == null ) {
 			throw new SuperCsvReflectionException(
 				String

--- a/super-csv/src/main/java/org/supercsv/util/ReflectionUtils.java
+++ b/super-csv/src/main/java/org/supercsv/util/ReflectionUtils.java
@@ -183,7 +183,15 @@ public final class ReflectionUtils {
 		if( setter == null && AUTOBOXING_CONVERTER.containsKey(argumentType) ) {
 			setter = findSetterWithCompatibleParamType(clazz, setterName, AUTOBOXING_CONVERTER.get(argumentType));
 		}
-		
+
+		if (setter == null) {
+			setter = findSetterWithCompatibleParamType(clazz, fieldName, argumentType);
+		}
+
+		if( setter == null && AUTOBOXING_CONVERTER.containsKey(argumentType) ) {
+			setter = findSetterWithCompatibleParamType(clazz, fieldName, AUTOBOXING_CONVERTER.get(argumentType));
+		}
+
 		if( setter == null ) {
 			throw new SuperCsvReflectionException(
 				String

--- a/super-csv/src/test/java/org/supercsv/mock/FluentCustomerBean.java
+++ b/super-csv/src/test/java/org/supercsv/mock/FluentCustomerBean.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.supercsv.mock;
+
+public class FluentCustomerBean {
+
+	private String customerName;
+
+	public FluentCustomerBean(String customerName) {
+		this.customerName = customerName;
+	}
+
+	public String customerName() {
+		return customerName;
+	}
+
+}

--- a/super-csv/src/test/java/org/supercsv/mock/FluentCustomerBean.java
+++ b/super-csv/src/test/java/org/supercsv/mock/FluentCustomerBean.java
@@ -17,12 +17,26 @@ public class FluentCustomerBean {
 
 	private String customerName;
 
-	public FluentCustomerBean(String customerName) {
+	private Integer customerAge;
+
+	public FluentCustomerBean(String customerName, Integer customerAge) {
 		this.customerName = customerName;
+		this.customerAge = customerAge;
 	}
 
 	public String customerName() {
 		return customerName;
 	}
 
+	public void customerName(String aName) {
+		this.customerName = aName;
+	}
+
+	public Integer customerAge() {
+		return customerAge;
+	}
+
+	public void customerAge(Integer customerAge) {
+		this.customerAge = customerAge;
+	}
 }

--- a/super-csv/src/test/java/org/supercsv/util/ReflectionUtilsTest.java
+++ b/super-csv/src/test/java/org/supercsv/util/ReflectionUtilsTest.java
@@ -81,7 +81,7 @@ public class ReflectionUtilsTest {
 	public void shouldFindFluentGetterNamedLikeField() throws Exception {
 		//given
 		String name = "John";
-		FluentCustomerBean bean = new FluentCustomerBean(name);
+		FluentCustomerBean bean = new FluentCustomerBean(name, 30);
 
 		//when
 		Method getter = findGetter(bean, "customerName");
@@ -147,6 +147,32 @@ public class ReflectionUtilsTest {
 	public void testFindSetterWithMethodOfSameName() throws Exception {
 		findSetter(bean, "primitiveBoolean", boolean.class).invoke(bean, true);
 		assertTrue(bean.isPrimitiveBoolean());
+	}
+
+	@Test
+	public void shouldFindFluentSetterNamedLikeField() throws Exception {
+		//given
+		String name = "Kate";
+		FluentCustomerBean bean = new FluentCustomerBean("John", 30);
+
+		//when
+		findSetter(bean, "customerName", String.class).invoke(bean, name);
+
+		//then
+		assertEquals(name, bean.customerName());
+	}
+
+	@Test
+	public void shouldFindFluentSetterIfArgumentTypeCanBeDeducedByAutoboxing() throws Exception {
+		//given
+		int age = 27;
+		FluentCustomerBean bean = new FluentCustomerBean("Cristina", age);
+
+		//when
+		findSetter(bean, "customerAge", int.class).invoke(bean, age);
+
+		//then
+		assertEquals(new Integer(age), bean.customerAge());
 	}
 
 	/**

--- a/super-csv/src/test/java/org/supercsv/util/ReflectionUtilsTest.java
+++ b/super-csv/src/test/java/org/supercsv/util/ReflectionUtilsTest.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2007 Kasper B. Graversen
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,25 +20,27 @@ import static org.junit.Assert.assertTrue;
 import static org.supercsv.util.ReflectionUtils.findGetter;
 import static org.supercsv.util.ReflectionUtils.findSetter;
 
-import java.lang.reflect.Constructor;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.supercsv.exception.SuperCsvReflectionException;
+import org.supercsv.mock.FluentCustomerBean;
 import org.supercsv.mock.ReflectionBean;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
 
 /**
  * Test the ReflectionUtils class.
- * 
+ *
  * @author James Bassett
  */
 public class ReflectionUtilsTest {
-	
+
 	private static final double DOUBLE_ASSERT_DELTA = 1e-15;
-	
+
 	private ReflectionBean bean;
-	
+
 	/**
 	 * Sets up before the test.
 	 */
@@ -46,7 +48,7 @@ public class ReflectionUtilsTest {
 	public void setUp() {
 		bean = new ReflectionBean();
 	}
-	
+
 	/**
 	 * Tidies up after the test.
 	 */
@@ -54,7 +56,7 @@ public class ReflectionUtilsTest {
 	public void tearDown() {
 		bean = null;
 	}
-	
+
 	/**
 	 * Tests the findGetter() method.
 	 */
@@ -64,7 +66,7 @@ public class ReflectionUtilsTest {
 		bean.setName(name);
 		assertEquals(name, findGetter(bean, "name").invoke(bean));
 	}
-	
+
 	/**
 	 * Tests the findGetter() method with an 'get' style boolean getter.
 	 */
@@ -74,7 +76,20 @@ public class ReflectionUtilsTest {
 		bean.setBooleanWrapper(boolValue);
 		assertEquals(boolValue, findGetter(bean, "booleanWrapper").invoke(bean));
 	}
-	
+
+	@Test
+	public void shouldFindFluentGetterNamedLikeField() throws Exception {
+		//given
+		String name = "John";
+		FluentCustomerBean bean = new FluentCustomerBean(name);
+
+		//when
+		Method getter = findGetter(bean, "customerName");
+
+		//then
+		assertEquals(name, getter.invoke(bean));
+	}
+
 	/**
 	 * Tests the findGetter() method with an 'is' style boolean getter.
 	 */
@@ -84,7 +99,7 @@ public class ReflectionUtilsTest {
 		bean.setPrimitiveBoolean(boolValue);
 		assertEquals(boolValue, findGetter(bean, "primitiveBoolean").invoke(bean));
 	}
-	
+
 	/**
 	 * Tests the findGetter() method with an 'is' style Boolean getter.
 	 */
@@ -94,7 +109,7 @@ public class ReflectionUtilsTest {
 		bean.setBooleanWrapper2(boolValue);
 		assertEquals(boolValue, findGetter(bean, "booleanWrapper2").invoke(bean));
 	}
-	
+
 	/**
 	 * Tests the findSetter() method.
 	 */
@@ -104,7 +119,7 @@ public class ReflectionUtilsTest {
 		findSetter(bean, "name", String.class).invoke(bean, name);
 		assertEquals(name, bean.getName());
 	}
-	
+
 	/**
 	 * Tests the findSetter() method with a field type that is a subtype of the setter parameter type.
 	 */
@@ -113,7 +128,7 @@ public class ReflectionUtilsTest {
 		findSetter(bean, "favouriteNumber", Integer.class).invoke(bean, Integer.valueOf(123));
 		assertEquals(123, bean.getFavouriteNumber().intValue());
 	}
-	
+
 	/**
 	 * Tests the findSetter() method with a field type that's compatible with 2 setters (the exact match should always
 	 * be used).
@@ -123,7 +138,7 @@ public class ReflectionUtilsTest {
 		findSetter(bean, "overloaded", Number.class).invoke(bean, Integer.valueOf(123));
 		assertEquals(123, bean.getOverloaded().intValue());
 	}
-	
+
 	/**
 	 * Tests the findSetter() method with a field type that's compatible with 1 setter but has the same name as another
 	 * method (which should be ignored).
@@ -133,7 +148,7 @@ public class ReflectionUtilsTest {
 		findSetter(bean, "primitiveBoolean", boolean.class).invoke(bean, true);
 		assertTrue(bean.isPrimitiveBoolean());
 	}
-	
+
 	/**
 	 * Tests the findGetter() method with a field name that is all capitals.
 	 */
@@ -143,7 +158,7 @@ public class ReflectionUtilsTest {
 		bean.setURL(url);
 		assertEquals(url, findGetter(bean, "URL").invoke(bean));
 	}
-	
+
 	/**
 	 * Tests the findSetter() method with a field name that is all capitals.
 	 */
@@ -153,7 +168,7 @@ public class ReflectionUtilsTest {
 		findSetter(bean, "URL", String.class).invoke(bean, url);
 		assertEquals(url, bean.getURL());
 	}
-	
+
 	/**
 	 * Tests the findGetter() method with a getter that has a lowercase char after 'get'.
 	 */
@@ -163,7 +178,7 @@ public class ReflectionUtilsTest {
 		bean.setiPad(value);
 		assertEquals(value, findGetter(bean, "iPad").invoke(bean));
 	}
-	
+
 	/**
 	 * Tests the findSetter() method with a setter that has a lowercase char after 'set'.
 	 */
@@ -193,68 +208,68 @@ public class ReflectionUtilsTest {
 		findSetter(bean, "isTurkish", Boolean.class).invoke(bean, value);
 		assertEquals(value, bean.getIsTurkish());
 	}
-	
+
 	/**
 	 * Tests the findSetter() method by passing primitives and wrapper classes to setters that expect wrapper classes
 	 * and primitives respectively (this tests the autoboxing logic).
 	 */
 	@Test
 	public void testAutoboxing() throws Exception {
-		
+
 		// first try setting wrapper values onto the primitive setters
-		
+
 		findSetter(bean, "primitiveBoolean", Boolean.class).invoke(bean, Boolean.TRUE);
 		assertEquals(true, bean.isPrimitiveBoolean());
-		
+
 		findSetter(bean, "primitiveInt", Integer.class).invoke(bean, Integer.valueOf(1));
 		assertEquals(1, bean.getPrimitiveInt());
-		
+
 		findSetter(bean, "primitiveShort", Short.class).invoke(bean, Short.valueOf("2"));
 		assertEquals(Short.parseShort("2"), bean.getPrimitiveShort());
-		
+
 		findSetter(bean, "primitiveLong", Long.class).invoke(bean, Long.valueOf("3"));
 		assertEquals(Long.parseLong("3"), bean.getPrimitiveLong());
-		
+
 		findSetter(bean, "primitiveDouble", Double.class).invoke(bean, Double.valueOf("4.0"));
 		assertEquals(Double.parseDouble("4.0"), bean.getPrimitiveDouble(), DOUBLE_ASSERT_DELTA);
-		
+
 		findSetter(bean, "primitiveFloat", Float.class).invoke(bean, Float.valueOf("5.0"));
 		assertEquals(Float.parseFloat("5.0"), bean.getPrimitiveFloat(), DOUBLE_ASSERT_DELTA);
-		
+
 		findSetter(bean, "primitiveChar", Character.class).invoke(bean, Character.valueOf('a'));
 		assertEquals('a', bean.getPrimitiveChar());
-		
+
 		findSetter(bean, "primitiveByte", Byte.class).invoke(bean, Byte.valueOf("123"));
 		assertEquals(Byte.parseByte("123"), bean.getPrimitiveByte());
-		
+
 		// now try setting primitive values onto the wrapper setters
-		
+
 		findSetter(bean, "booleanWrapper", boolean.class).invoke(bean, true);
 		assertEquals(Boolean.TRUE, bean.getBooleanWrapper());
-		
+
 		findSetter(bean, "integerWrapper", int.class).invoke(bean, 1);
 		assertEquals(Integer.valueOf(1), bean.getIntegerWrapper());
-		
+
 		findSetter(bean, "shortWrapper", short.class).invoke(bean, Short.parseShort("2"));
 		assertEquals(Short.valueOf("2"), bean.getShortWrapper());
-		
+
 		findSetter(bean, "longWrapper", long.class).invoke(bean, Long.parseLong("3"));
 		assertEquals(Long.valueOf("3"), bean.getLongWrapper());
-		
+
 		findSetter(bean, "doubleWrapper", double.class).invoke(bean, Double.parseDouble("4.0"));
 		assertEquals(Double.valueOf("4.0"), bean.getDoubleWrapper());
-		
+
 		findSetter(bean, "floatWrapper", float.class).invoke(bean, Float.parseFloat("5.0"));
 		assertEquals(Float.valueOf("5.0"), bean.getFloatWrapper());
-		
+
 		findSetter(bean, "charWrapper", char.class).invoke(bean, 'a');
 		assertEquals(Character.valueOf('a'), bean.getCharWrapper());
-		
+
 		findSetter(bean, "byteWrapper", byte.class).invoke(bean, Byte.parseByte("123"));
 		assertEquals(Byte.valueOf("123"), bean.getByteWrapper());
-		
+
 	}
-	
+
 	/**
 	 * Tests the findGetter() method with a null object (should throw an exception).
 	 */
@@ -262,7 +277,7 @@ public class ReflectionUtilsTest {
 	public void testFindGetterWithNullObject() {
 		findGetter(null, "name");
 	}
-	
+
 	/**
 	 * Tests the findGetter() method with a null field name (should throw an exception).
 	 */
@@ -270,7 +285,7 @@ public class ReflectionUtilsTest {
 	public void testFindGetterWithNullFieldName() {
 		findGetter(bean, null);
 	}
-	
+
 	/**
 	 * Tests the findGetter() method with an invalid field name (should throw an exception).
 	 */
@@ -278,7 +293,7 @@ public class ReflectionUtilsTest {
 	public void testFindGetterWithInvalidFieldName() {
 		findGetter(bean, "invalid");
 	}
-	
+
 	/**
 	 * Tests the findSetter() method with a null object (should throw an exception).
 	 */
@@ -286,7 +301,7 @@ public class ReflectionUtilsTest {
 	public void testFindSetterWithNullObject() {
 		findSetter(null, "name", String.class);
 	}
-	
+
 	/**
 	 * Tests the findSetter() method with a null field name (should throw an exception).
 	 */
@@ -294,7 +309,7 @@ public class ReflectionUtilsTest {
 	public void testFindSetterWithNullFieldName() {
 		findSetter(bean, null, String.class);
 	}
-	
+
 	/**
 	 * Tests the findSetter() method with a null field type (should throw an exception).
 	 */
@@ -302,7 +317,7 @@ public class ReflectionUtilsTest {
 	public void testFindSetterWithNullFieldType() {
 		findSetter(bean, "name", null);
 	}
-	
+
 	/**
 	 * Tests the findSetter() method with an invalid field name (should throw an exception).
 	 */
@@ -310,7 +325,7 @@ public class ReflectionUtilsTest {
 	public void testFindSetterWithInvalidFieldName() {
 		findSetter(bean, "invalid", String.class);
 	}
-	
+
 	/**
 	 * Tests the findSetter() method with an invalid field name with a primitive parameter type (should throw an
 	 * exception after trying both primitive and wrapper method signatures).
@@ -319,7 +334,7 @@ public class ReflectionUtilsTest {
 	public void testFindSetterWithInvalidFieldNameAndPrimitiveType() {
 		findSetter(bean, "invalid", int.class);
 	}
-	
+
 	/**
 	 * Tests the private constructor for test coverage (yes, this is stupid).
 	 */
@@ -329,5 +344,5 @@ public class ReflectionUtilsTest {
 		c.setAccessible(true);
 		c.newInstance();
 	}
-	
+
 }


### PR DESCRIPTION
When writing the bean to csv, use fluent getters and setters to get/set field values.

It also works if bean is a java record.